### PR TITLE
feat(cli-api): Add custom flag for config files

### DIFF
--- a/.changeset/neat-turtles-bake.md
+++ b/.changeset/neat-turtles-bake.md
@@ -1,0 +1,8 @@
+---
+"@tylerbu/cli-api": minor
+---
+
+Add custom flag for config files
+
+The `ConfigFileFlag` flag can be used with `CommandWithConfig` subclasses to enable passing a specific path to a config
+file.

--- a/packages/cli-api/api-docs/cli-api.api.md
+++ b/packages/cli-api/api-docs/cli-api.api.md
@@ -72,7 +72,7 @@ export abstract class CommandWithConfig<T extends typeof Command & {
     // (undocumented)
     init(): Promise<void>;
     // (undocumented)
-    protected loadConfig(): Promise<C | undefined>;
+    protected loadConfig(filePath?: string): Promise<C | undefined>;
 }
 
 // @beta
@@ -84,6 +84,17 @@ export abstract class CommandWithoutConfig<T extends typeof Command & {
 
 // @beta (undocumented)
 export type CommitMergeability = "clean" | "conflict" | "maybeClean";
+
+// @beta (undocumented)
+export const ConfigFileFlag: FlagDefinition<string, ConfigFlagConfig, {
+multiple: false;
+requiredOrDefaulted: false;
+}>;
+
+// @beta (undocumented)
+export type ConfigFlagConfig = {
+    exists?: boolean;
+};
 
 // @public
 export type ErrorLoggingFunction = (msg: string | Error | undefined, ...args: unknown[]) => void;

--- a/packages/cli-api/src/configCommand.ts
+++ b/packages/cli-api/src/configCommand.ts
@@ -1,7 +1,8 @@
-import { existsSync } from "node:fs";
+import { stat } from "node:fs/promises";
 import type { Command } from "@oclif/core";
 import { type CosmiconfigResult, cosmiconfig } from "cosmiconfig";
 import { BaseCommand } from "./baseCommand.js";
+import { findGitRoot } from "./git.js";
 
 /**
  * A base command that loads typed configuration values from a config file.
@@ -23,30 +24,33 @@ export abstract class CommandWithConfig<
 
 	public override async init(): Promise<void> {
 		await super.init();
-		this.commandConfig = await this.loadConfig();
+		const { config } = this.flags;
+		this.commandConfig = await this.loadConfig(config);
 	}
 
-	protected async loadConfig(): Promise<C | undefined> {
-		const configPath = this.config.configDir; // path.join(this.config.configDir, "config.ts");
-		// const config = await this.loadConfigFromFile(this.config.configDir);
+	protected async loadConfig(filePath?: string): Promise<C | undefined> {
+		const configPath = filePath ?? process.cwd();
 		const moduleName = this.config.bin;
+		const repoRoot = await findGitRoot();
 		const explorer = cosmiconfig(moduleName, {
 			searchStrategy: "global",
+			stopDir: repoRoot,
 		});
+		const pathStats = await stat(configPath);
 		this.verbose(`Looking for '${this.config.bin}' config at '${configPath}'`);
-		if (existsSync(configPath)) {
-			const config: CosmiconfigResult = await explorer.search(configPath);
-			if (config?.config !== undefined) {
-				this.verbose(`Found config at ${config.filepath}`);
-			}
-			return config?.config as C | undefined;
+		let config: CosmiconfigResult;
+		if (pathStats.isDirectory()) {
+			config = await explorer.search(configPath);
+		} else {
+			config = await explorer.load(configPath);
 		}
+		if (config?.config !== undefined) {
+			this.verbose(`Found config at ${config.filepath}`);
+		} else {
+			this.verbose(`No config found; started searching at ${configPath}`);
+		}
+		return config?.config as C | undefined;
 	}
-
-	// private async loadConfigFromFile(
-	// 	configPath: string,
-	// ): Promise<C | undefined> {
-	// }
 
 	protected get defaultConfig(): C | undefined {
 		return undefined;

--- a/packages/cli-api/src/flags.ts
+++ b/packages/cli-api/src/flags.ts
@@ -1,3 +1,4 @@
+import { stat } from "node:fs/promises";
 import { Flags } from "@oclif/core";
 
 // export const regexFlag = Flags.custom<
@@ -10,5 +11,28 @@ export const RegExpFlag = Flags.custom<RegExp>({
 	parse: async (input) => {
 		const policyRegex: RegExp = new RegExp(input, "i");
 		return policyRegex;
+	},
+});
+
+/**
+ * @beta
+ */
+export type ConfigFlagConfig = {
+	exists?: boolean;
+};
+
+/**
+ * @beta
+ */
+export const ConfigFileFlag = Flags.custom<string, ConfigFlagConfig>({
+	description: "The path to a configuration file.",
+	parse: async (input, _, options): Promise<string | undefined> => {
+		if (options.exists === true) {
+			const statResults = await stat(input);
+			if (!statResults.isFile()) {
+				throw new Error(`Config file doesn't exist: ${input}`);
+			}
+		}
+		return undefined;
 	},
 });

--- a/packages/cli-api/src/index.ts
+++ b/packages/cli-api/src/index.ts
@@ -1,6 +1,10 @@
 export { type Args, type Flags, BaseCommand } from "./baseCommand.js";
 export { CommandWithConfig, CommandWithoutConfig } from "./configCommand.js";
-export { RegExpFlag } from "./flags.js";
+export {
+	RegExpFlag,
+	ConfigFileFlag,
+	type ConfigFlagConfig,
+} from "./flags.js";
 export type { CommitMergeability } from "./git.js";
 export { findGitRoot } from "./git.js";
 export { GitCommand } from "./gitCommand.js";


### PR DESCRIPTION
The `ConfigFileFlag` flag can be used with `CommandWithConfig` subclasses to enable passing a specific path to a config
file.