### PR TITLE
fix(cli-api): move `sort-package-json` from devDependencies to dependencies

### DIFF
--- a/.changeset/clean-flowers-tell.md
+++ b/.changeset/clean-flowers-tell.md
@@ -1,0 +1,7 @@
+---
+"@tylerbu/cli-api": patch
+---
+
+Add missing sort-package-json dependency
+
+Thanks to [@ic4l4s9c](https://github.com/ic4l4s9c) for this fix!

--- a/packages/cli-api/package.json
+++ b/packages/cli-api/package.json
@@ -40,6 +40,7 @@
 		"detect-indent": "^7.0.1",
 		"jsonfile": "^6.1.0",
 		"simple-git": "^3.24.0",
+		"sort-package-json": "2.10.0",
 		"strip-ansi": "^7.1.0"
 	},
 	"devDependencies": {
@@ -58,7 +59,6 @@
 		"mocha": "^10.4.0",
 		"oclif": "^4.14.26",
 		"rimraf": "^6.0.0",
-		"sort-package-json": "2.10.0",
 		"tmp-promise": "^3.0.3",
 		"ts-node": "^10.9.2",
 		"tslib": "^2.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
       simple-git:
         specifier: ^3.24.0
         version: 3.27.0
+      sort-package-json:
+        specifier: 2.10.0
+        version: 2.10.0
       strip-ansi:
         specifier: ^7.1.0
         version: 7.1.0
@@ -259,9 +262,6 @@ importers:
       rimraf:
         specifier: ^6.0.0
         version: 6.0.1
-      sort-package-json:
-        specifier: 2.10.0
-        version: 2.10.0
       tmp-promise:
         specifier: ^3.0.3
         version: 3.0.3
@@ -3184,6 +3184,9 @@ packages:
 
   '@types/node@17.0.45':
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
+
+  '@types/node@18.19.71':
+    resolution: {integrity: sha512-evXpcgtZm8FY4jqBSN8+DmOTcVkkvTmAayeo4Wf3m1xAruyVGzGuDh/Fb/WWX2yLItUiho42ozyJjB0dw//Tkw==}
 
   '@types/node@20.16.10':
     resolution: {integrity: sha512-vQUKgWTjEIRFCvK6CyriPH3MZYiYlNy0fKiEYHWbcoWLEgs4opurGGKlebrTLqdSMIbXImH6XExNiIyNUv3WpA==}
@@ -8814,6 +8817,9 @@ packages:
   underscore@1.13.7:
     resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
@@ -13689,6 +13695,11 @@ snapshots:
 
   '@types/node@17.0.45': {}
 
+  '@types/node@18.19.71':
+    dependencies:
+      undici-types: 5.26.5
+    optional: true
+
   '@types/node@20.16.10':
     dependencies:
       undici-types: 6.19.8
@@ -13744,7 +13755,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 20.16.10
+      '@types/node': 18.19.71
     optional: true
 
   '@ungap/structured-clone@1.2.0': {}
@@ -20833,6 +20844,9 @@ snapshots:
       which-boxed-primitive: 1.0.2
 
   underscore@1.13.7: {}
+
+  undici-types@5.26.5:
+    optional: true
 
   undici-types@6.19.8: {}
 


### PR DESCRIPTION
As of now `sort-tsconfig` is unusable to run as cli:
```
npx sort-tsconfig
Need to install the following packages:
sort-tsconfig@0.1.3
Ok to proceed? (y) y

 ›   ModuleLoadError: [MODULE_NOT_FOUND] import() failed to load ~/.npm/_npx/827b70e7db1a8ec3/node_modules/sort-tsconfig/esm/commands/sort-tsconfig.js: Cannot find 
 ›   package 'sort-package-json' imported from ~/.npm/_npx/827b70e7db1a8ec3/node_modules/@tylerbu/cli-api/esm/json.js
 ›   Code: MODULE_NOT_FOUND
```

Since published `@tylerbu/cli-api` package imports `sort-package-json`, `sort-package-json` should be moved from devDependencies to dependencies. 

![image](https://github.com/user-attachments/assets/15e9a772-f2eb-4519-824b-d885b18d234f)
