### PR TITLE
refactor(repopo): Use effection for structured concurrency

### DIFF
--- a/packages/repopo-docs/src/content/docs/api/functions/generateFileHeaderPolicy.md
+++ b/packages/repopo-docs/src/content/docs/api/functions/generateFileHeaderPolicy.md
@@ -7,7 +7,7 @@ title: "generateFileHeaderPolicy"
 
 > **generateFileHeaderPolicy**(`name`, `config`): [`PolicyDefinition`](/api/interfaces/policydefinition/)\<[`FileHeaderPolicyConfig`](/api/interfaces/fileheaderpolicyconfig/)\>
 
-Defined in: [policyDefiners/defineFileHeaderPolicy.ts:63](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L63)
+Defined in: [policyDefiners/defineFileHeaderPolicy.ts:64](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L64)
 
 Given a [FileHeaderPolicyConfig](/api/interfaces/fileheaderpolicyconfig/), produces a function that detects correct file headers
 and returns an error string if the header is missing or incorrect.

--- a/packages/repopo-docs/src/content/docs/api/functions/generatePackagePolicy.md
+++ b/packages/repopo-docs/src/content/docs/api/functions/generatePackagePolicy.md
@@ -7,7 +7,7 @@ title: "generatePackagePolicy"
 
 > **generatePackagePolicy**\<`J`, `C`\>(`name`, `packagePolicy`): [`PolicyDefinition`](/api/interfaces/policydefinition/)\<`C`\>
 
-Defined in: [policyDefiners/definePackagePolicy.ts:27](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/definePackagePolicy.ts#L27)
+Defined in: [policyDefiners/definePackagePolicy.ts:28](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/definePackagePolicy.ts#L28)
 
 Define a repo policy for package.json files.
 

--- a/packages/repopo-docs/src/content/docs/api/interfaces/FileHeaderGeneratorConfig.md
+++ b/packages/repopo-docs/src/content/docs/api/interfaces/FileHeaderGeneratorConfig.md
@@ -5,7 +5,7 @@ prev: false
 title: "FileHeaderGeneratorConfig"
 ---
 
-Defined in: [policyDefiners/defineFileHeaderPolicy.ts:30](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L30)
+Defined in: [policyDefiners/defineFileHeaderPolicy.ts:31](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L31)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -21,7 +21,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **autoGenText**: `string`
 
-Defined in: [policyDefiners/defineFileHeaderPolicy.ts:24](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L24)
+Defined in: [policyDefiners/defineFileHeaderPolicy.ts:25](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L25)
 
 An optional string that will be appended to the headerText.
 
@@ -39,7 +39,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **headerEnd**: [`RegExp`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
 
-Defined in: [policyDefiners/defineFileHeaderPolicy.ts:52](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L52)
+Defined in: [policyDefiners/defineFileHeaderPolicy.ts:53](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L53)
 
 Regex matching the header postfix.
 
@@ -53,7 +53,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **headerStart**: [`RegExp`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
 
-Defined in: [policyDefiners/defineFileHeaderPolicy.ts:37](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L37)
+Defined in: [policyDefiners/defineFileHeaderPolicy.ts:38](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L38)
 
 Regex matching header prefix (e.g. `/*!\r?\n`)
 
@@ -67,7 +67,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **headerText**: `string`
 
-Defined in: [policyDefiners/defineFileHeaderPolicy.ts:19](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L19)
+Defined in: [policyDefiners/defineFileHeaderPolicy.ts:20](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L20)
 
 The text to use as the header.
 
@@ -85,7 +85,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **lineEnd**: [`RegExp`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
 
-Defined in: [policyDefiners/defineFileHeaderPolicy.ts:47](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L47)
+Defined in: [policyDefiners/defineFileHeaderPolicy.ts:48](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L48)
 
 Regex matching the end of each line (e.g., `\r?\n`)
 
@@ -99,7 +99,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **lineStart**: [`RegExp`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
 
-Defined in: [policyDefiners/defineFileHeaderPolicy.ts:42](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L42)
+Defined in: [policyDefiners/defineFileHeaderPolicy.ts:43](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L43)
 
 Regex matching beginning of each line (e.g. ' * ')
 
@@ -113,7 +113,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **match**: [`RegExp`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
 
-Defined in: [policyDefiners/defineFileHeaderPolicy.ts:32](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L32)
+Defined in: [policyDefiners/defineFileHeaderPolicy.ts:33](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L33)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -125,7 +125,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **replacer**: (`content`, `config`) => `string`
 
-Defined in: [policyDefiners/defineFileHeaderPolicy.ts:54](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L54)
+Defined in: [policyDefiners/defineFileHeaderPolicy.ts:55](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L55)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.

--- a/packages/repopo-docs/src/content/docs/api/interfaces/FileHeaderPolicyConfig.md
+++ b/packages/repopo-docs/src/content/docs/api/interfaces/FileHeaderPolicyConfig.md
@@ -5,7 +5,7 @@ prev: false
 title: "FileHeaderPolicyConfig"
 ---
 
-Defined in: [policyDefiners/defineFileHeaderPolicy.ts:15](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L15)
+Defined in: [policyDefiners/defineFileHeaderPolicy.ts:16](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L16)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -17,7 +17,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **autoGenText**: `string`
 
-Defined in: [policyDefiners/defineFileHeaderPolicy.ts:24](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L24)
+Defined in: [policyDefiners/defineFileHeaderPolicy.ts:25](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L25)
 
 An optional string that will be appended to the headerText.
 
@@ -31,7 +31,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **headerText**: `string`
 
-Defined in: [policyDefiners/defineFileHeaderPolicy.ts:19](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L19)
+Defined in: [policyDefiners/defineFileHeaderPolicy.ts:20](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts#L20)
 
 The text to use as the header.
 

--- a/packages/repopo-docs/src/content/docs/api/interfaces/PolicyDefinition.md
+++ b/packages/repopo-docs/src/content/docs/api/interfaces/PolicyDefinition.md
@@ -5,7 +5,7 @@ prev: false
 title: "PolicyDefinition"
 ---
 
-Defined in: [policy.ts:82](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L82)
+Defined in: [policy.ts:78](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L78)
 
 A RepoPolicyDefinition checks and applies policies to files in the repository.
 
@@ -33,7 +33,7 @@ type of configuration object used by the policy
 
 > `optional` **defaultConfig**: `C`
 
-Defined in: [policy.ts:121](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L121)
+Defined in: [policy.ts:117](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L117)
 
 A default config that will be used if none is provided.
 
@@ -47,7 +47,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **description**: `string`
 
-Defined in: [policy.ts:91](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L91)
+Defined in: [policy.ts:87](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L87)
 
 A more detailed description of the policy and its intended function.
 
@@ -61,7 +61,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **handler**: [`PolicyHandler`](/api/type-aliases/policyhandler/)\<`C`\>
 
-Defined in: [policy.ts:107](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L107)
+Defined in: [policy.ts:103](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L103)
 
 A handler function that checks if a file is compliant with the policy.
 
@@ -91,7 +91,7 @@ True if the file passed the policy; otherwise a PolicyFailure object will be ret
 
 > **match**: [`RegExp`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
 
-Defined in: [policy.ts:96](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L96)
+Defined in: [policy.ts:92](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L92)
 
 A regular expression that is used to match files in the repo.
 
@@ -105,7 +105,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **name**: `string`
 
-Defined in: [policy.ts:86](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L86)
+Defined in: [policy.ts:82](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L82)
 
 The name of the policy; displayed in UI and used in settings.
 
@@ -119,7 +119,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **resolver**: [`PolicyStandaloneResolver`](/api/type-aliases/policystandaloneresolver/)\<`C`\>
 
-Defined in: [policy.ts:116](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L116)
+Defined in: [policy.ts:112](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L112)
 
 A resolver function that can be used to automatically address the policy violation.
 

--- a/packages/repopo-docs/src/content/docs/api/interfaces/PolicyFailure.md
+++ b/packages/repopo-docs/src/content/docs/api/interfaces/PolicyFailure.md
@@ -5,7 +5,7 @@ prev: false
 title: "PolicyFailure"
 ---
 
-Defined in: [policy.ts:153](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L153)
+Defined in: [policy.ts:149](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L149)
 
 A policy failure.
 
@@ -23,7 +23,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **autoFixable**: `boolean`
 
-Defined in: [policy.ts:167](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L167)
+Defined in: [policy.ts:163](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L163)
 
 Set to `true` if the policy can be fixed automatically.
 
@@ -37,7 +37,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **errorMessage**: `string`
 
-Defined in: [policy.ts:172](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L172)
+Defined in: [policy.ts:168](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L168)
 
 An optional error message accompanying the failure.
 
@@ -51,7 +51,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **file**: `string`
 
-Defined in: [policy.ts:162](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L162)
+Defined in: [policy.ts:158](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L158)
 
 Path to the file that failed the policy.
 
@@ -65,7 +65,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **name**: `string`
 
-Defined in: [policy.ts:157](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L157)
+Defined in: [policy.ts:153](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L153)
 
 Name of the policy that failed.
 

--- a/packages/repopo-docs/src/content/docs/api/interfaces/PolicyFixResult.md
+++ b/packages/repopo-docs/src/content/docs/api/interfaces/PolicyFixResult.md
@@ -5,7 +5,7 @@ prev: false
 title: "PolicyFixResult"
 ---
 
-Defined in: [policy.ts:180](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L180)
+Defined in: [policy.ts:176](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L176)
 
 The result of an automatic fix for a failing policy.
 
@@ -23,7 +23,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **autoFixable**: `boolean`
 
-Defined in: [policy.ts:167](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L167)
+Defined in: [policy.ts:163](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L163)
 
 Set to `true` if the policy can be fixed automatically.
 
@@ -41,7 +41,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **errorMessage**: `string`
 
-Defined in: [policy.ts:172](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L172)
+Defined in: [policy.ts:168](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L168)
 
 An optional error message accompanying the failure.
 
@@ -59,7 +59,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **file**: `string`
 
-Defined in: [policy.ts:162](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L162)
+Defined in: [policy.ts:158](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L158)
 
 Path to the file that failed the policy.
 
@@ -77,7 +77,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **name**: `string`
 
-Defined in: [policy.ts:157](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L157)
+Defined in: [policy.ts:153](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L153)
 
 Name of the policy that failed.
 
@@ -95,7 +95,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **resolved**: `boolean`
 
-Defined in: [policy.ts:184](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L184)
+Defined in: [policy.ts:180](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L180)
 
 Set to true if the failure was resolved by the automated fixer.
 

--- a/packages/repopo-docs/src/content/docs/api/interfaces/PolicyFunctionArguments.md
+++ b/packages/repopo-docs/src/content/docs/api/interfaces/PolicyFunctionArguments.md
@@ -5,7 +5,7 @@ prev: false
 title: "PolicyFunctionArguments"
 ---
 
-Defined in: [policy.ts:19](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L19)
+Defined in: [policy.ts:20](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L20)
 
 Arguments passed to policy functions.
 
@@ -25,7 +25,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **config**: `C`
 
-Defined in: [policy.ts:40](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L40)
+Defined in: [policy.ts:41](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L41)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -41,7 +41,7 @@ Note that the handler function receives the config as an argument.
 
 > **file**: `string`
 
-Defined in: [policy.ts:23](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L23)
+Defined in: [policy.ts:24](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L24)
 
 Path to the file, relative to the repo root.
 
@@ -55,7 +55,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **resolve**: `boolean`
 
-Defined in: [policy.ts:33](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L33)
+Defined in: [policy.ts:34](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L34)
 
 If true, the handler should resolve any violations automatically if possible.
 
@@ -69,7 +69,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **root**: `string`
 
-Defined in: [policy.ts:28](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L28)
+Defined in: [policy.ts:29](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L29)
 
 Absolute path to the root of the repo.
 

--- a/packages/repopo-docs/src/content/docs/api/interfaces/PolicyInstanceSettings.md
+++ b/packages/repopo-docs/src/content/docs/api/interfaces/PolicyInstanceSettings.md
@@ -5,7 +5,7 @@ prev: false
 title: "PolicyInstanceSettings"
 ---
 
-Defined in: [policy.ts:127](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L127)
+Defined in: [policy.ts:123](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L123)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -23,7 +23,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **config**: `C`
 
-Defined in: [policy.ts:139](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L139)
+Defined in: [policy.ts:135](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L135)
 
 The config that is applied to the policy instance.
 
@@ -37,7 +37,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **excludeFiles**: (`string` \| [`RegExp`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp))[]
 
-Defined in: [policy.ts:134](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L134)
+Defined in: [policy.ts:130](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L130)
 
 An array of strings/regular expressions. File paths that match any of these expressions will be completely excluded
 from policy.

--- a/packages/repopo-docs/src/content/docs/api/type-aliases/PackageJsonHandler.md
+++ b/packages/repopo-docs/src/content/docs/api/type-aliases/PackageJsonHandler.md
@@ -5,9 +5,9 @@ prev: false
 title: "PackageJsonHandler"
 ---
 
-> **PackageJsonHandler**\<`J`, `C`\> = (`json`, `args`) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`PolicyHandlerResult`](/api/type-aliases/policyhandlerresult/)\>
+> **PackageJsonHandler**\<`J`, `C`\> = (`json`, `args`) => `Operation`\<[`PolicyHandlerResult`](/api/type-aliases/policyhandlerresult/)\>
 
-Defined in: [policyDefiners/definePackagePolicy.ts:17](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/definePackagePolicy.ts#L17)
+Defined in: [policyDefiners/definePackagePolicy.ts:18](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policyDefiners/definePackagePolicy.ts#L18)
 
 A policy handler especially for policies that target package.json.
 
@@ -37,4 +37,4 @@ This API should not be used in production and may be trimmed from a public relea
 
 ## Returns
 
-[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`PolicyHandlerResult`](/api/type-aliases/policyhandlerresult/)\>
+`Operation`\<[`PolicyHandlerResult`](/api/type-aliases/policyhandlerresult/)\>

--- a/packages/repopo-docs/src/content/docs/api/type-aliases/PolicyHandler.md
+++ b/packages/repopo-docs/src/content/docs/api/type-aliases/PolicyHandler.md
@@ -5,9 +5,9 @@ prev: false
 title: "PolicyHandler"
 ---
 
-> **PolicyHandler**\<`C`\> = (`args`) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`PolicyHandlerResult`](/api/type-aliases/policyhandlerresult/)\>
+> **PolicyHandler**\<`C`\> = (`args`) => `Operation`\<[`PolicyHandlerResult`](/api/type-aliases/policyhandlerresult/)\>
 
-Defined in: [policy.ts:49](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L49)
+Defined in: [policy.ts:50](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L50)
 
 A policy handler is a function that is called to check policy against a file.
 
@@ -29,4 +29,4 @@ This API should not be used in production and may be trimmed from a public relea
 
 ## Returns
 
-[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`PolicyHandlerResult`](/api/type-aliases/policyhandlerresult/)\>
+`Operation`\<[`PolicyHandlerResult`](/api/type-aliases/policyhandlerresult/)\>

--- a/packages/repopo-docs/src/content/docs/api/type-aliases/PolicyHandlerResult.md
+++ b/packages/repopo-docs/src/content/docs/api/type-aliases/PolicyHandlerResult.md
@@ -7,7 +7,7 @@ title: "PolicyHandlerResult"
 
 > **PolicyHandlerResult** = `true` \| [`PolicyFailure`](/api/interfaces/policyfailure/) \| [`PolicyFixResult`](/api/interfaces/policyfixresult/)
 
-Defined in: [policy.ts:190](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L190)
+Defined in: [policy.ts:186](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L186)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.

--- a/packages/repopo-docs/src/content/docs/api/type-aliases/PolicyInstance.md
+++ b/packages/repopo-docs/src/content/docs/api/type-aliases/PolicyInstance.md
@@ -7,7 +7,7 @@ title: "PolicyInstance"
 
 > **PolicyInstance**\<`C`\> = [`PolicyDefinition`](/api/interfaces/policydefinition/)\<`C`\> & [`PolicyInstanceSettings`](/api/interfaces/policyinstancesettings/)\<`C`\>
 
-Defined in: [policy.ts:145](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L145)
+Defined in: [policy.ts:141](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L141)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.

--- a/packages/repopo-docs/src/content/docs/api/type-aliases/PolicyName.md
+++ b/packages/repopo-docs/src/content/docs/api/type-aliases/PolicyName.md
@@ -7,7 +7,7 @@ title: "PolicyName"
 
 > **PolicyName** = `string`
 
-Defined in: [policy.ts:11](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L11)
+Defined in: [policy.ts:12](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L12)
 
 A type representing a policy name.
 

--- a/packages/repopo-docs/src/content/docs/api/type-aliases/PolicyStandaloneResolver.md
+++ b/packages/repopo-docs/src/content/docs/api/type-aliases/PolicyStandaloneResolver.md
@@ -5,9 +5,9 @@ prev: false
 title: "PolicyStandaloneResolver"
 ---
 
-> **PolicyStandaloneResolver**\<`C`\> = (`args`) => [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`PolicyFixResult`](/api/interfaces/policyfixresult/)\>
+> **PolicyStandaloneResolver**\<`C`\> = (`args`) => `Operation`\<[`PolicyFixResult`](/api/interfaces/policyfixresult/)\>
 
-Defined in: [policy.ts:63](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L63)
+Defined in: [policy.ts:59](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/policy.ts#L59)
 
 A standalone function that can be called to resolve a policy failure.
 
@@ -29,4 +29,4 @@ This API should not be used in production and may be trimmed from a public relea
 
 ## Returns
 
-[`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`PolicyFixResult`](/api/interfaces/policyfixresult/)\>
+`Operation`\<[`PolicyFixResult`](/api/interfaces/policyfixresult/)\>

--- a/packages/repopo/api-docs/repopo.api.md
+++ b/packages/repopo/api-docs/repopo.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { Operation } from 'effection';
 import type { PackageJson } from 'type-fest';
 import { run } from '@oclif/core';
 
@@ -35,7 +36,7 @@ export function generatePackagePolicy<J = PackageJson, C = undefined>(name: stri
 export function makePolicy<C>(definition: PolicyDefinition<C>, config?: C, settings?: PolicyInstanceSettings<C>): PolicyInstance<C>;
 
 // @alpha
-export type PackageJsonHandler<J, C> = (json: J, args: PolicyFunctionArguments<C>) => Promise<PolicyHandlerResult>;
+export type PackageJsonHandler<J, C> = (json: J, args: PolicyFunctionArguments<C>) => Operation<PolicyHandlerResult>;
 
 // @alpha
 export interface PolicyDefinition<C = undefined> {
@@ -70,7 +71,7 @@ export interface PolicyFunctionArguments<C> {
 }
 
 // @alpha
-export type PolicyHandler<C = unknown | undefined> = (args: PolicyFunctionArguments<C>) => Promise<PolicyHandlerResult>;
+export type PolicyHandler<C = unknown | undefined> = (args: PolicyFunctionArguments<C>) => Operation<PolicyHandlerResult>;
 
 // @alpha (undocumented)
 export type PolicyHandlerResult = true | PolicyFailure | PolicyFixResult;
@@ -88,7 +89,7 @@ export interface PolicyInstanceSettings<C> {
 export type PolicyName = string;
 
 // @alpha
-export type PolicyStandaloneResolver<C = undefined> = (args: Omit<PolicyFunctionArguments<C>, "resolve">) => Promise<PolicyFixResult>;
+export type PolicyStandaloneResolver<C = undefined> = (args: Omit<PolicyFunctionArguments<C>, "resolve">) => Operation<PolicyFixResult>;
 
 // @alpha (undocumented)
 export interface RepopoConfig {

--- a/packages/repopo/package.json
+++ b/packages/repopo/package.json
@@ -79,6 +79,7 @@
 		"@tylerbu/cli-api": "workspace:^",
 		"@tylerbu/fundamentals": "workspace:^",
 		"defu": "^6.1.4",
+		"effection": "^3.5.0",
 		"jsonfile": "^6.1.0",
 		"microdiff": "^1.5.0",
 		"pathe": "^2.0.3",

--- a/packages/repopo/src/perf.ts
+++ b/packages/repopo/src/perf.ts
@@ -1,4 +1,5 @@
 import type { Logger } from "@tylerbu/cli-api";
+import type { Operation } from "effection";
 import type { PolicyName } from "./policy.js";
 
 export type PolicyAction = "handle" | "resolve";
@@ -17,17 +18,17 @@ export function newPerfStats(): PolicyHandlerPerfStats {
 	};
 }
 
-export async function runWithPerf<T>(
+export function* runWithPerf<T extends Operation<T>>(
 	name: string,
 	action: PolicyAction,
 	stats: PolicyHandlerPerfStats,
-	run: () => Promise<T>,
-): Promise<T> {
+	run: () => Operation<T>,
+): Operation<T> {
 	const actionMap = stats.data.get(action) ?? new Map<string, number>();
 	let dur = actionMap.get(name) ?? 0;
 
 	const start = Date.now();
-	const result = await run();
+	const result = yield* run();
 	dur += Date.now() - start;
 
 	actionMap.set(name, dur);

--- a/packages/repopo/src/perf.ts
+++ b/packages/repopo/src/perf.ts
@@ -18,7 +18,7 @@ export function newPerfStats(): PolicyHandlerPerfStats {
 	};
 }
 
-export function* runWithPerf<T extends Operation<T>>(
+export function* runWithPerf<T>(
 	name: string,
 	action: PolicyAction,
 	stats: PolicyHandlerPerfStats,

--- a/packages/repopo/src/policies/NoJsFileExtensions.ts
+++ b/packages/repopo/src/policies/NoJsFileExtensions.ts
@@ -1,4 +1,4 @@
-import { type Operation, call, lift } from "effection";
+import type { Operation } from "effection";
 import { makePolicyDefinition } from "../makePolicy.js";
 import type { PolicyDefinition, PolicyFailure } from "../policy.js";
 

--- a/packages/repopo/src/policies/NoJsFileExtensions.ts
+++ b/packages/repopo/src/policies/NoJsFileExtensions.ts
@@ -1,3 +1,4 @@
+import { type Operation, call, lift } from "effection";
 import { makePolicyDefinition } from "../makePolicy.js";
 import type { PolicyDefinition, PolicyFailure } from "../policy.js";
 
@@ -13,8 +14,8 @@ import type { PolicyDefinition, PolicyFailure } from "../policy.js";
 export const NoJsFileExtensions: PolicyDefinition = makePolicyDefinition(
 	"NoJsFileExtensions",
 	/(^|\/)[^/]+\.js$/i,
-	// biome-ignore lint/suspicious/useAwait: <explanation>
-	async ({ file }) => {
+	// biome-ignore lint/correctness/useYield: <explanation>
+	function* ({ file }): Operation<PolicyFailure> {
 		// Any match is considered a failure.
 		const result: PolicyFailure = {
 			name: NoJsFileExtensions.name,

--- a/packages/repopo/src/policies/PackageJsonProperties.ts
+++ b/packages/repopo/src/policies/PackageJsonProperties.ts
@@ -1,4 +1,5 @@
 import { defu } from "defu";
+import { call } from "effection";
 import jsonfile from "jsonfile";
 import diff from "microdiff";
 import type { PackageJson } from "type-fest";
@@ -27,7 +28,7 @@ export interface PackageJsonPropertiesSettings {
 export const PackageJsonProperties = definePackagePolicy<
 	PackageJson,
 	PackageJsonPropertiesSettings | undefined
->("PackageJsonProperties", async (json, { file, config, resolve }) => {
+>("PackageJsonProperties", function* (json, { file, config, resolve }) {
 	if (config === undefined) {
 		return true;
 	}
@@ -56,7 +57,7 @@ export const PackageJsonProperties = definePackagePolicy<
 				resolved: false,
 			};
 
-			await writeJson(file, merged, { spaces: "\t" });
+			yield* call(() => writeJson(file, merged, { spaces: "\t" }));
 
 			fixResult.resolved = true;
 			return fixResult;

--- a/packages/repopo/src/policies/PackageJsonRepoDirectoryProperty.ts
+++ b/packages/repopo/src/policies/PackageJsonRepoDirectoryProperty.ts
@@ -2,11 +2,7 @@ import assert from "node:assert/strict";
 import { updatePackageJsonFile } from "@fluid-tools/build-infrastructure";
 import path from "pathe";
 import type { PackageJson } from "type-fest";
-import type {
-	PolicyFailure,
-	PolicyFixResult,
-	PolicyHandlerResult,
-} from "../policy.js";
+import type { PolicyFailure, PolicyFixResult } from "../policy.js";
 import { definePackagePolicy } from "../policyDefiners/definePackagePolicy.js";
 
 /**

--- a/packages/repopo/src/policies/PackageJsonSorted.ts
+++ b/packages/repopo/src/policies/PackageJsonSorted.ts
@@ -1,4 +1,5 @@
 import { updatePackageJsonFile } from "@tylerbu/cli-api";
+import { call } from "effection";
 import { sortPackageJson } from "sort-package-json";
 import type { PolicyFailure, PolicyFixResult } from "../policy.js";
 import { definePackagePolicy } from "../policyDefiners/definePackagePolicy.js";
@@ -10,7 +11,7 @@ import { definePackagePolicy } from "../policyDefiners/definePackagePolicy.js";
  */
 export const PackageJsonSorted = definePackagePolicy(
 	"PackageJsonSorted",
-	async (json, { file, resolve }) => {
+	function* (json, { file, resolve }) {
 		const sortedJson = sortPackageJson(json);
 		const isSorted = JSON.stringify(sortedJson) === JSON.stringify(json);
 
@@ -20,7 +21,9 @@ export const PackageJsonSorted = definePackagePolicy(
 
 		if (resolve) {
 			try {
-				await updatePackageJsonFile(file, (json) => json, { sort: true });
+				yield* call(() =>
+					updatePackageJsonFile(file, (json) => json, { sort: true }),
+				);
 				const result: PolicyFixResult = {
 					name: PackageJsonSorted.name,
 					file,

--- a/packages/repopo/src/policies/PackageScripts.ts
+++ b/packages/repopo/src/policies/PackageScripts.ts
@@ -10,7 +10,7 @@ const expectedScripts = ["build", "clean"] as const;
  */
 export const PackageScripts = definePackagePolicy(
 	"PackageScripts",
-	async (json, { file }) => {
+	function* (json, { file }) {
 		const failResult: PolicyFailure = {
 			name: PackageScripts.name,
 			file,

--- a/packages/repopo/src/policy.ts
+++ b/packages/repopo/src/policy.ts
@@ -1,3 +1,4 @@
+import type { Operation } from "effection";
 import { NoJsFileExtensions } from "./policies/NoJsFileExtensions.js";
 import { PackageJsonRepoDirectoryProperty } from "./policies/PackageJsonRepoDirectoryProperty.js";
 import { PackageJsonSorted } from "./policies/PackageJsonSorted.js";
@@ -48,12 +49,7 @@ export interface PolicyFunctionArguments<C> {
 
 export type PolicyHandler<C = unknown | undefined> = (
 	args: PolicyFunctionArguments<C>,
-) => Promise<PolicyHandlerResult>;
-
-// export type PolicyCheckOnly = (
-// 	file: string,
-// 	root: string,
-// ) => Promise<PolicyHandlerResult>;
+) => Operation<PolicyHandlerResult>;
 
 /**
  * A standalone function that can be called to resolve a policy failure.
@@ -62,7 +58,7 @@ export type PolicyHandler<C = unknown | undefined> = (
  */
 export type PolicyStandaloneResolver<C = undefined> = (
 	args: Omit<PolicyFunctionArguments<C>, "resolve">,
-) => Promise<PolicyFixResult>;
+) => Operation<PolicyFixResult>;
 
 // function isPolicyHandler(input: PolicyHandler | PolicyCheckOnly): input is PolicyHandler
 

--- a/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts
+++ b/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { EOL as newline } from "node:os";
+import { call } from "effection";
 import { extname } from "pathe";
 import type {
 	PolicyDefinition,
@@ -90,7 +91,7 @@ export function defineFileHeaderPolicy(
 	return {
 		name,
 		match: config.match,
-		handler: async ({ file, resolve, config: policyConfig }) => {
+		handler: function* ({ file, resolve, config: policyConfig }) {
 			if (policyConfig === undefined) {
 				return true;
 			}
@@ -103,7 +104,7 @@ export function defineFileHeaderPolicy(
 
 			// TODO: Consider reading only the first 512B or so since headers are typically
 			// at the beginning of the file.
-			const content = await readFile(file, { encoding: "utf8" });
+			const content = yield* call(() => readFile(file, { encoding: "utf8" }));
 			const failed = !regex.test(content);
 
 			if (failed) {
@@ -113,7 +114,7 @@ export function defineFileHeaderPolicy(
 			if (failed) {
 				if (resolve) {
 					const newContent = config.replacer(content, policyConfig);
-					await writeFile(file, newContent);
+					yield* call(() => writeFile(file, newContent));
 
 					const fixResult: PolicyFixResult = {
 						...failResult,

--- a/packages/repopo/src/policyDefiners/definePackagePolicy.ts
+++ b/packages/repopo/src/policyDefiners/definePackagePolicy.ts
@@ -1,3 +1,4 @@
+import { type Operation, call } from "effection";
 import jsonfile from "jsonfile";
 import type { PackageJson } from "type-fest";
 import { PackageJsonRegexMatch } from "../policies/constants.js";
@@ -17,7 +18,7 @@ const { readFile: readJson } = jsonfile;
 export type PackageJsonHandler<J, C> = (
 	json: J,
 	args: PolicyFunctionArguments<C>,
-) => Promise<PolicyHandlerResult>;
+) => Operation<PolicyHandlerResult>;
 
 /**
  * Define a repo policy for package.json files.
@@ -33,9 +34,9 @@ export function definePackagePolicy<J = PackageJson, C = undefined>(
 	return {
 		name,
 		match: PackageJsonRegexMatch,
-		handler: async (innerArgs) => {
-			const json: J = await readJson(innerArgs.file);
-			return packagePolicy(json, innerArgs);
+		handler: function* (innerArgs) {
+			const json: J = yield* call(() => readJson(innerArgs.file));
+			return yield* packagePolicy(json, innerArgs);
 		},
 	};
 }

--- a/packages/sort-tsconfig/src/policy.ts
+++ b/packages/sort-tsconfig/src/policy.ts
@@ -9,8 +9,8 @@ import { isSorted, sortTsconfigFile } from "sort-tsconfig";
 export const SortTsconfigsPolicy: PolicyDefinition = {
 	name: "SortTsconfigs",
 	match: /.*\.?tsconfig\.json$/i,
-	// biome-ignore lint/suspicious/useAwait: <explanation>
-	handler: async ({ file, config, resolve }) => {
+	// biome-ignore lint/correctness/useYield: no yield needed
+	handler: function* ({ file, config, resolve }) {
 		if (config === undefined) {
 			return true;
 		}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -685,6 +685,9 @@ importers:
       defu:
         specifier: ^6.1.4
         version: 6.1.4
+      effection:
+        specifier: ^3.5.0
+        version: 3.5.0
       jsonfile:
         specifier: ^6.1.0
         version: 6.1.0
@@ -5523,6 +5526,10 @@ packages:
 
   effect@3.14.0:
     resolution: {integrity: sha512-Ggb3biSS+2q3Uv+S0YBcKFbhbPCNfIkGOtYnqllmRD9DssT1I8pUMKghn6Vzi5wH693+yB3UVcBJUMz7kYFq4g==}
+
+  effection@3.5.0:
+    resolution: {integrity: sha512-PcKRGoP68CM3c/DODTc38xp0rIjfREH7/fBGu4tiHU/aPb/PvSxv3tvWaJt6JxpxqT0jIXvcOyn+yjk46KcNXw==}
+    engines: {node: '>= 16'}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -19191,6 +19198,8 @@ snapshots:
     dependencies:
       '@standard-schema/spec': 1.0.0
       fast-check: 3.23.2
+
+  effection@3.5.0: {}
 
   ejs@3.1.10:
     dependencies:


### PR DESCRIPTION
Repopo now uses [effection](https://www.npmjs.com/package/effection) for structured concurrency management internally. It is probably overkill for a project like this, but it is a nice showcase of what effection code looks like, including some async/await interop.