### PR TITLE
chore: improve CI workflow and turborepo configuration

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -17,6 +17,10 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_REMOTE_CACHE_SIGNATURE_KEY: ${{ secrets.TURBO_REMOTE_CACHE_SIGNATURE_KEY }}
 
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
@@ -38,28 +42,25 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache@v4
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.run_id }}
           restore-keys: |
+            ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}-
             ${{ runner.os }}-turbo-
 
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm run ci:check || echo "FAIL_WORKFLOW=true" >> $GITHUB_ENV
-        continue-on-error: true
-      - run: pnpm run ci:build
-      - run: pnpm run ci:check:typedoc || echo "FAIL_WORKFLOW=true" >> $GITHUB_ENV
-        continue-on-error: true
-      - run: pnpm run ci:lint || echo "FAIL_WORKFLOW=true" >> $GITHUB_ENV
-        continue-on-error: true
-      - run: pnpm run ci:docs || echo "FAIL_WORKFLOW=true" >> $GITHUB_ENV
-        continue-on-error: true
-      - run: pnpm run ci:test
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run CI checks, builds, and tests
+        run: pnpm run ci
 
       - name: "Codecov: upload test results"
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # ratchet:codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: "Codecov: upload coverage"
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # ratchet:codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -68,7 +69,3 @@ jobs:
         run: |
           git diff
           git diff --quiet || (git status -u . && exit 1)
-
-      - name: Fail workflow if any step failed
-        if: ${{ env.FAIL_WORKFLOW == 'true' }}
-        run: exit 1

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"check:format": "biome check --linter-enabled=false",
 		"check:policy": "./packages/repopo/bin/dev.js check",
 		"check:renovate-config": "renovate-config-validator",
-		"ci": "npm run ci:check && npm run ci:build && npm run ci:lint && npm run ci:test",
+		"ci": "turbo run check build check:typedoc lint docs test:coverage --continue --output-logs=errors-only",
 		"ci:build": "turbo run build generate",
 		"ci:check": "npm run check",
 		"ci:check:typedoc": "turbo run check:typedoc",

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,9 @@
 {
 	"$schema": "https://turborepo.org/schema.json",
 	"ui": "stream",
+	"remoteCache": {
+		"signature": true
+	},
 	"globalDependencies": [
 		"config/tsconfig*.json",
 		"config/api-extractor.base.json",
@@ -10,6 +13,7 @@
 	"tasks": {
 		"build": {
 			"dependsOn": ["^build"],
+			"inputs": ["$TURBO_DEFAULT$", "!test/**", "!**/*.test.ts"],
 			"outputs": [
 				"esm/**",
 				"dist/**",


### PR DESCRIPTION
## Summary
- Simplify CI workflow to single consolidated `turbo run` command
- Add remote cache configuration with signature verification for faster builds
- Optimize GitHub Actions cache strategy using `pnpm-lock.yaml` hash
- Add `--continue` flag and `--output-logs=errors-only` for better CI experience

## Changes
**GitHub Actions Workflow** (`.github/workflows/pr-build.yml`):
- Consolidated multiple CI steps into single command: `pnpm run ci`
- Improved cache key to use `pnpm-lock.yaml` hash for better cache hits
- Added Turborepo environment variables for remote caching
- Removed individual continue-on-error steps in favor of `--continue` flag

**Package.json**:
- Updated `ci` script to use optimized turbo command with error-only output

**Turbo.json**:
- Added `remoteCache` configuration with signature verification
- Enables cache sharing across CI runs for faster builds

## Benefits
✅ Faster CI execution with better cache utilization  
✅ Cleaner output showing only errors  
✅ More maintainable single-command approach  
✅ Remote cache sharing reduces redundant builds