### PR TITLE
feat(ci): integrate lockfile version sync in dependabot workflow

### DIFF
--- a/.github/workflows/dependabot-build-artifacts.yml
+++ b/.github/workflows/dependabot-build-artifacts.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Sync lockfile versions
+        run: pnpm deps:sync --execute
+
       - name: Build packages
         run: pnpm run ci:build
 


### PR DESCRIPTION
## Summary

- Integrates `sync-lockfile-versions` script into the Dependabot build artifacts workflow
- Ensures package.json versions are automatically synchronized with lockfile during CI
- Addresses Dependabot bug where caret ranges prevent version updates in package.json

## Changes

Added sync step that runs after dependency installation and before building packages:
```yaml
- name: Sync lockfile versions
  run: pnpm deps:sync --execute
```

## Test plan

- [ ] Verify workflow runs successfully on Dependabot PRs
- [ ] Confirm package.json versions are updated to match lockfile
- [ ] Validate build artifacts are generated correctly after sync