### PR TITLE
fix(ci): update lockfile after version sync in dependabot workflow

### DIFF
--- a/.github/workflows/dependabot-build-artifacts.yml
+++ b/.github/workflows/dependabot-build-artifacts.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Sync lockfile versions
         run: pnpm deps:sync --execute
 
+      - name: Update lockfile
+        run: pnpm install --no-frozen-lockfile
+
       - name: Build packages
         run: pnpm run ci:build
 


### PR DESCRIPTION
## Summary
- Add `pnpm install --no-frozen-lockfile` step after version sync in dependabot workflow
- Ensures lockfile reflects synchronized dependency versions before build

## Problem
The dependabot workflow runs `pnpm deps:sync --execute` to synchronize lockfile versions, but doesn't update the lockfile afterwards. This causes version mismatches between package.json and pnpm-lock.yaml when building.

## Solution
Added a lockfile update step after version sync to ensure consistency before the build phase.

## Test plan
- [x] Workflow file syntax is valid
- [ ] Verify workflow runs successfully on next dependabot PR
- [ ] Confirm build succeeds with synchronized versions