### PR TITLE
ci: run full CI on main branch

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -55,8 +55,13 @@ jobs:
       # Sets NX_BASE and NX_HEAD for accurate affected detection
       - uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # ratchet:nrwl/nx-set-shas@v4
 
-      - name: Run affected CI checks, builds, and tests
-        run: pnpm run ci
+      - name: Run CI checks, builds, and tests
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            pnpm run ci:all
+          else
+            pnpm run ci
+          fi
 
       - run: npx nx fix-ci
         if: always()


### PR DESCRIPTION
## Summary
- Run `pnpm ci:all` on main branch to test all projects
- Keep `pnpm ci` (affected-only) for pull requests to maintain fast feedback

## Rationale
When code is merged to main, we want comprehensive testing across all projects to ensure nothing breaks. For PRs, affected-only testing provides faster feedback while still catching relevant issues.

## Changes
- Updated `.github/workflows/pr-build.yml` to conditionally run `ci:all` on main branch