### PR TITLE
ci: use BundleMon groups to avoid content-hash noise

### DIFF
--- a/packages/ccl-test-viewer/.bundlemonrc.mjs
+++ b/packages/ccl-test-viewer/.bundlemonrc.mjs
@@ -1,30 +1,24 @@
 export default {
 	baseDir: "./build",
-	files: [
+	// Use groups instead of individual files to avoid content-hash rename noise
+	groups: [
 		{
+			name: "JavaScript",
 			path: "_app/**/*.js",
 			maxSize: "500kb",
 			maxPercentIncrease: 10,
 		},
 		{
+			name: "CSS",
 			path: "_app/**/*.css",
 			maxSize: "100kb",
 			maxPercentIncrease: 10,
 		},
 		{
+			name: "Chunks",
 			path: "_app/immutable/chunks/*.js",
 			maxSize: "200kb",
 			maxPercentIncrease: 5,
-		},
-	],
-	groups: [
-		{
-			name: "JavaScript",
-			path: "_app/**/*.js",
-		},
-		{
-			name: "CSS",
-			path: "_app/**/*.css",
 		},
 	],
 	reportOutput: ["github", "console"],


### PR DESCRIPTION
## Problem

BundleMon was showing noisy PR comments with many files "added" and "removed" when Vite's content-hashed filenames changed between builds, even when actual bundle size changes were minimal.

Example from PR #412:
- 8 files "added" (e.g., `Cu3UyC4K.js` +10.76KB)
- 8 files "removed" (e.g., `eoRanmzH.js` -10.76KB)  
- Net change: +6B (0%)

## Solution

Switched from tracking individual file patterns to using **groups** that aggregate files regardless of hash names.

### Before
```javascript
files: [
  { path: "_app/**/*.js", maxSize: "500kb", maxPercentIncrease: 10 },
  // ... tracked individual hashed files
]
groups: [
  { name: "JavaScript", path: "_app/**/*.js" },
  // ... no size limits
]
```

### After  
```javascript
groups: [
  { name: "JavaScript", path: "_app/**/*.js", maxSize: "500kb", maxPercentIncrease: 10 },
  { name: "CSS", path: "_app/**/*.css", maxSize: "100kb", maxPercentIncrease: 10 },
  { name: "Chunks", path: "_app/immutable/chunks/*.js", maxSize: "200kb", maxPercentIncrease: 5 },
]
```

## Expected Result

PR comments will now show clean aggregate metrics:
- ✅ JavaScript: 450KB (+6B, 0%)
- ✅ CSS: 85KB (0B, 0%)
- ✅ Chunks: 180KB (0B, 0%)

No more noise from content-hash renames, while maintaining the same size limit protections.

## Testing

The next PR to `ccl-test-viewer` will demonstrate the cleaner BundleMon reporting.

Fixes the reporting issue observed in #412