### PR TITLE
build: add CLAUDE.md for all packages

### DIFF
--- a/packages/cli-api/CLAUDE.md
+++ b/packages/cli-api/CLAUDE.md
@@ -1,0 +1,254 @@
+# CLAUDE.md - @tylerbu/cli-api
+
+Package-specific guidance for the shared CLI command infrastructure library.
+
+## Package Overview
+
+Base classes and API helpers for OCLIF-based CLI projects. This library provides reusable command base classes that add common functionality like configuration file support and git operations to OCLIF commands.
+
+**Key Features:**
+- `CommandWithConfig` - Base class adding configuration file loading
+- `GitCommand` - Base class adding git operations via simple-git
+- Config file loading via lilconfig (supports multiple formats)
+- Type-safe flag and argument handling
+- Colorized output utilities
+
+## Development Commands
+
+```bash
+# Build the package
+pnpm build
+
+# Run tests
+pnpm test
+
+# Run tests with coverage
+pnpm test:coverage
+
+# Format code
+pnpm format
+
+# Lint code
+pnpm lint
+pnpm lint:fix  # Auto-fix issues
+
+# Check formatting
+pnpm check
+
+# Generate API documentation
+pnpm build:api
+
+# Clean build artifacts
+pnpm clean
+```
+
+## Key Exports
+
+### CommandWithConfig
+
+Base class that adds configuration file loading to OCLIF commands:
+
+```typescript
+import { CommandWithConfig } from "@tylerbu/cli-api";
+
+export default class MyCommand extends CommandWithConfig<typeof MyCommand> {
+  public static override readonly flags = {
+    ...CommandWithConfig.flags,  // Inherits --config flag
+  };
+
+  public override async run(): Promise<void> {
+    // Config loaded automatically from:
+    // - .myapprc (JSON/YAML)
+    // - .myapprc.json
+    // - .myapprc.yaml/yml
+    // - myapp.config.js/cjs/mjs/ts
+    // - myapp property in package.json
+    // - Or path specified via --config flag
+  }
+}
+```
+
+**Config Loading:**
+- Uses lilconfig for flexible config file discovery
+- Supports TypeScript config files via @tylerbu/lilconfig-loader-ts
+- Config file name determined by OCLIF's `dirname` property
+- Searches from current directory upward
+
+### GitCommand
+
+Base class that adds git operations:
+
+```typescript
+import { GitCommand } from "@tylerbu/cli-api";
+
+export default class MyGitCommand extends GitCommand<typeof MyGitCommand> {
+  public static override readonly flags = {
+    ...GitCommand.flags,  // Inherits git-related flags
+  };
+
+  public override async run(): Promise<void> {
+    // this.git is available (simple-git instance)
+    const status = await this.git.status();
+    const branches = await this.git.branch();
+
+    // Git-aware error handling
+    // redirectLogToTrace - control log verbosity
+  }
+}
+```
+
+**Provided Features:**
+- `this.git` - Initialized simple-git instance
+- Git repository detection and validation
+- Git-aware error handling
+
+### Utilities
+
+**Output Formatting:**
+```typescript
+import { chalk } from "@tylerbu/cli-api";
+
+// Colorized console output
+console.log(chalk.green("Success!"));
+console.log(chalk.red("Error!"));
+console.log(chalk.yellow("Warning!"));
+```
+
+## Configuration System
+
+The configuration loading system uses lilconfig and supports multiple file formats:
+
+**Supported Config Files:**
+- `.${appName}rc` (JSON or YAML)
+- `.${appName}rc.json`
+- `.${appName}rc.yaml` / `.${appName}rc.yml`
+- `${appName}.config.js` / `.cjs` / `.mjs` / `.ts`
+- `${appName}` property in `package.json`
+
+**TypeScript Config Support:**
+TypeScript config files are automatically supported via the integrated lilconfig-loader-ts.
+
+## Project Structure
+
+```
+packages/cli-api/
+├── src/
+│   ├── index.ts              # Main exports
+│   ├── BaseCommand.ts        # CommandWithConfig implementation
+│   ├── GitCommand.ts         # GitCommand implementation
+│   └── utils/                # Utility functions
+├── esm/                      # Compiled output
+├── test/                     # Vitest tests
+├── package.json
+└── tsconfig.json
+```
+
+## Testing Strategy
+
+Uses Vitest for unit testing:
+
+```bash
+# Run tests
+pnpm test
+
+# Run with coverage
+pnpm test:coverage
+
+# Watch mode
+pnpm test -- --watch
+```
+
+**Test Structure:**
+- Unit tests in `test/` directory
+- Test files: `*.test.ts`
+- Coverage output in `.coverage/`
+
+## Integration with Other Packages
+
+This package is used by:
+- **@tylerbu/cli** - Personal CLI tool
+- **dill-cli** - File download utility
+- **repopo** - Repository policy tool
+- **sort-tsconfig** - TypeScript config sorter
+
+When modifying base classes, consider impact on all consuming packages.
+
+## Common Patterns
+
+### Extending CommandWithConfig
+
+```typescript
+import { CommandWithConfig } from "@tylerbu/cli-api";
+import { Args, Flags } from "@oclif/core";
+
+export default class MyCommand extends CommandWithConfig<typeof MyCommand> {
+  public static override readonly description = "My command description";
+
+  public static override readonly flags = {
+    myFlag: Flags.boolean({ description: "My flag" }),
+    ...CommandWithConfig.flags,  // Inherit config flag
+  };
+
+  public static override readonly args = {
+    myArg: Args.string({ required: true }),
+  };
+
+  public override async run(): Promise<void> {
+    const { flags, args } = this;
+    // Config automatically loaded
+    // Access via this.config property
+  }
+}
+```
+
+### Extending GitCommand
+
+```typescript
+import { GitCommand } from "@tylerbu/cli-api";
+import { Flags } from "@oclif/core";
+
+export default class MyGitCommand extends GitCommand<typeof MyGitCommand> {
+  public static override readonly description = "Git command";
+
+  public static override readonly flags = {
+    branch: Flags.string({ description: "Branch name" }),
+    ...GitCommand.flags,
+  };
+
+  public override async run(): Promise<void> {
+    // Validate we're in a git repo
+    if (!await this.git.checkIsRepo()) {
+      this.error("Not in a git repository");
+    }
+
+    // Perform git operations
+    const currentBranch = await this.git.revparse(["--abbrev-ref", "HEAD"]);
+    this.log(`Current branch: ${currentBranch}`);
+  }
+}
+```
+
+## Important Constraints
+
+1. **Part of Monorepo**: Uses `workspace:^` protocol for internal dependencies
+2. **OCLIF Compatibility**: Designed for OCLIF v4+
+3. **TypeScript**: Strict mode enabled
+4. **Zero Runtime Config**: Config files loaded via lilconfig at runtime
+5. **Biome Formatting**: Code must pass Biome checks
+6. **Test Coverage**: Maintain test coverage for new features
+
+## Dependencies
+
+**Runtime:**
+- `@oclif/core` - OCLIF framework
+- `@tylerbu/fundamentals` - Shared utilities
+- `@tylerbu/lilconfig-loader-ts` - TypeScript config loader
+- `lilconfig` - Config file loading
+- `simple-git` - Git operations
+- `sort-package-json` - Package.json sorting
+
+**Key Features:**
+- Minimal dependencies
+- Reusable across multiple CLI projects
+- Type-safe configuration
+- Extensible base classes

--- a/packages/dill-cli/CLAUDE.md
+++ b/packages/dill-cli/CLAUDE.md
@@ -1,0 +1,298 @@
+# CLAUDE.md - dill-cli
+
+Package-specific guidance for the file download and extraction CLI tool.
+
+## Package Overview
+
+Dill is a command-line tool to download and optionally decompress gzipped files. Built with OCLIF and Effection for structured concurrency, it provides a robust solution for downloading and extracting archives in CI/CD pipelines and development workflows.
+
+**Binary:** `dill`
+**Dev Mode:** `./bin/dev.js`
+**Prod Mode:** `./bin/run.js`
+**Documentation:** https://dill.tylerbutler.com/
+
+**Key Features:**
+- Download files from URLs
+- Automatic decompression (gzip, tar.gz)
+- Progress bars and status indicators
+- Content-type detection
+- Filename extraction from Content-Disposition headers
+- Built with Effection for cancellable operations
+
+## Essential Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the package
+pnpm build
+
+# Run tests
+pnpm test
+
+# Run tests with coverage
+pnpm test:coverage
+
+# Format code
+pnpm format
+
+# Lint code
+pnpm lint
+pnpm lint:fix  # Auto-fix issues
+
+# Check formatting
+pnpm check
+
+# Generate OCLIF manifest
+pnpm build:manifest
+
+# Update README from command help
+pnpm build:readme
+
+# Update command snapshots
+./bin/dev.js snapshot:generate
+./bin/dev.js snapshot:compare
+
+# Clean build artifacts
+pnpm clean
+```
+
+## Using Dill CLI
+
+```bash
+# Development mode (no compilation needed)
+./bin/dev.js <url> [output]
+
+# Examples:
+./bin/dev.js https://example.com/file.tar.gz
+./bin/dev.js https://example.com/file.tar.gz ./output.tar.gz
+./bin/dev.js https://example.com/file.tar.gz --extract
+
+# Production mode
+dill <url> [output]
+
+# Download and extract
+dill https://example.com/archive.tar.gz --extract
+
+# Download to specific location
+dill https://example.com/file.zip ./downloads/file.zip
+
+# Show help
+dill --help
+```
+
+## Command Structure
+
+Dill uses a **single-command strategy** in OCLIF - the main command is directly accessible without subcommands:
+
+```
+src/
+├── commands/
+│   └── download.ts        # Main download command
+├── lib/
+│   ├── download.ts        # Download implementation (Effection)
+│   ├── extract.ts         # Extraction logic
+│   └── progress.ts        # Progress bar utilities
+└── index.ts              # Public API exports
+```
+
+**Exportable Command:**
+The download command is exported at `dill-cli/command` for reuse in other CLI tools (e.g., `@tylerbu/cli` re-exports it as the `download` command).
+
+## Architecture
+
+### Effection-Based Concurrency
+
+Dill uses Effection for structured concurrency:
+
+```typescript
+import { main, stream } from "effection";
+
+// Operations are cancellable and composable
+await main(function* () {
+  let response = yield* fetch(url);
+  let body = yield* stream(response.body);
+
+  for (let chunk of body) {
+    // Process streaming data
+  }
+});
+```
+
+**Benefits:**
+- Automatic cleanup on errors
+- Cancellable operations
+- Structured control flow
+- Resource management
+
+### File Type Detection
+
+```typescript
+import { FileTypeResult, fileTypeStream } from "file-type";
+import { parseContentType } from "whatwg-mimetype";
+
+// Detect file types from content and headers
+const contentType = parseContentType(response.headers.get("content-type"));
+const fileType = await fileTypeFromStream(stream);
+```
+
+### Extraction Support
+
+Supports multiple archive formats:
+- **tar** - TAR archives (via nanotar)
+- **gzip** - Gzip compression (via fflate)
+- **tar.gz** - Gzipped TAR archives
+
+## Testing Strategy
+
+### Unit Tests (Vitest)
+
+```bash
+# Run tests
+pnpm test
+
+# Watch mode
+pnpm test -- --watch
+
+# Coverage
+pnpm test:coverage
+```
+
+**Test Structure:**
+- Unit tests in `test/` directory
+- Uses `memfs` for filesystem mocking
+- Uses `msw` (Mock Service Worker) for HTTP mocking
+- Coverage output in `.coverage/`
+
+### Command Snapshot Tests
+
+```bash
+# Generate snapshots
+./bin/dev.js snapshot:generate --filepath test/commands/__snapshots__/commands.json
+
+# Verify snapshots
+./bin/dev.js snapshot:compare --filepath test/commands/__snapshots__/commands.json
+```
+
+Uses `@oclif/plugin-command-snapshot` to validate command structure, flags, and help text.
+
+### Integration Tests
+
+```bash
+# Start local file server
+pnpm start  # Serves test/data on port 8080
+
+# Run integration tests
+pnpm test -- --grep integration
+```
+
+## OCLIF Configuration
+
+Dill uses a **single-command strategy**:
+
+```json
+{
+  "oclif": {
+    "bin": "dill",
+    "commands": {
+      "strategy": "single",
+      "target": "./esm/commands/download.js"
+    }
+  }
+}
+```
+
+This means `dill` directly invokes the download command without requiring a subcommand name.
+
+**Custom Help Options:**
+- Hidden aliases from root
+- Stripped ANSI colors
+- Custom usage header
+- Flag options shown in title
+
+## Build Artifacts
+
+```
+bin/                      # Binary entry points
+esm/                      # Compiled TypeScript
+oclif.manifest.json       # Command manifest (auto-generated)
+README.md                # Auto-generated from command help
+```
+
+**Never edit manually:**
+- `oclif.manifest.json` - Run `pnpm build:manifest`
+- README.md command sections - Run `pnpm build:readme`
+
+## Common Workflows
+
+### Adding a New Flag or Option
+
+1. Update `src/commands/download.ts` flags
+2. Modify implementation in `src/lib/download.ts`
+3. Run `./bin/dev.js --help` to test
+4. Update manifest: `pnpm build:manifest`
+5. Update README: `pnpm build:readme`
+6. Update snapshots: `./bin/dev.js snapshot:generate`
+7. Run tests: `pnpm test`
+
+### Adding Extraction Support for New Format
+
+1. Add format detection in `src/lib/extract.ts`
+2. Implement extraction logic
+3. Add tests in `test/extract.test.ts`
+4. Update documentation
+
+### Debugging Downloads
+
+```bash
+# Run with debug output
+DEBUG=* ./bin/dev.js <url>
+
+# OCLIF debug mode
+DEBUG=oclif:* ./bin/dev.js <url>
+```
+
+## Integration with @tylerbu/cli
+
+The `@tylerbu/cli` package re-exports dill's download command:
+
+```typescript
+// In @tylerbu/cli/src/commands/download.ts
+export { default } from "dill-cli/command";
+```
+
+This pattern allows sharing command implementations across CLI tools.
+
+## Important Constraints
+
+1. **Part of Monorepo**: Uses `workspace:^` protocol for dependencies
+2. **Single Command**: No subcommands, direct invocation
+3. **Effection Required**: All async operations use Effection
+4. **TypeScript**: Strict mode enabled
+5. **OCLIF Structure**: Follow OCLIF conventions
+6. **Command Exportable**: Main command must be importable
+7. **Biome Formatting**: Code must pass Biome checks
+
+## Dependencies
+
+**Key Runtime Dependencies:**
+- `@oclif/core` - CLI framework
+- `@tylerbu/cli-api` - Base command classes
+- `effection` - Structured concurrency
+- `fflate` - Fast compression/decompression
+- `nanotar` - TAR archive handling
+- `file-type` - File type detection
+- `whatwg-mimetype` - MIME type parsing
+
+**Key Dev Dependencies:**
+- `vitest` - Testing framework
+- `msw` - HTTP request mocking
+- `memfs` - In-memory filesystem
+- `@oclif/plugin-command-snapshot` - Command snapshot testing
+
+## Related Documentation
+
+- **User Docs**: https://dill.tylerbutler.com/
+- **API Docs**: Generated via TypeDoc at `dill-docs` package
+- **Examples**: See `test/data/` for test files

--- a/packages/dill-docs/CLAUDE.md
+++ b/packages/dill-docs/CLAUDE.md
@@ -1,0 +1,296 @@
+# CLAUDE.md - dill-docs
+
+Package-specific guidance for the Dill documentation site.
+
+## Package Overview
+
+Documentation website for the Dill CLI tool, built with Astro and Starlight. The site provides user guides, CLI reference documentation, and API documentation.
+
+**Site URL:** https://dill.tylerbutler.com/
+**Framework:** Astro with Starlight theme
+**Deployment:** Netlify
+
+## Essential Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Start development server
+pnpm dev
+# or
+pnpm start
+
+# Build site for production
+pnpm build:site
+
+# Preview production build
+pnpm preview
+
+# Check Astro configuration
+pnpm check:astro
+
+# Clean build artifacts
+pnpm clean
+```
+
+## Development Workflow
+
+### Local Development
+
+```bash
+# Start dev server with hot reload
+pnpm dev
+
+# Site available at http://localhost:4321 (default)
+```
+
+The dev server provides:
+- Hot module replacement (HMR)
+- Instant page updates on file changes
+- Error overlay for debugging
+
+### Building for Production
+
+```bash
+# Build static site
+pnpm build:site
+
+# Output: dist/ directory
+
+# Preview production build locally
+pnpm preview
+```
+
+## Project Structure
+
+```
+packages/dill-docs/
+├── src/
+│   ├── content/
+│   │   └── docs/          # Documentation markdown files
+│   │       ├── index.md   # Homepage
+│   │       ├── cli-reference.md  # Auto-generated CLI docs
+│   │       └── ...        # Other documentation pages
+│   ├── assets/            # Images, fonts, etc.
+│   └── styles/            # Custom styles
+├── astro.config.mjs       # Astro configuration
+├── dist/                  # Build output (generated)
+├── package.json
+└── tsconfig.json
+```
+
+## Astro Configuration
+
+Key features enabled in `astro.config.mjs`:
+
+**Starlight Theme:**
+- Documentation-focused theme
+- Built-in search
+- Responsive navigation
+- Dark mode support
+
+**Plugins:**
+- `starlight-heading-badges` - Badges for headings
+- `starlight-links-validator` - Validate internal links
+- `starlight-package-managers` - Package manager tabs
+- `starlight-typedoc` - TypeDoc API documentation
+
+**Netlify Adapter:**
+- Server-side rendering (SSR) support
+- Edge functions
+- Automatic deployment
+
+## Content Management
+
+### Writing Documentation
+
+Documentation files use Markdown with frontmatter:
+
+```markdown
+---
+title: Page Title
+description: Page description for SEO
+---
+
+# Page Title
+
+Content goes here...
+```
+
+**Starlight Features:**
+- Automatic table of contents
+- Syntax highlighting for code blocks
+- Callouts (note, tip, warning, danger)
+- Tabs for content variants
+
+### CLI Reference
+
+The CLI reference (`src/content/docs/cli-reference.md`) is **auto-generated** from the dill-cli package:
+
+```bash
+# In dill-cli package:
+pnpm build:readme
+
+# This updates both:
+# - dill-cli/README.md
+# - dill-docs/src/content/docs/cli-reference.md
+```
+
+**Never edit cli-reference.md manually** - changes will be overwritten.
+
+## TypeDoc Integration
+
+API documentation is generated from the dill-cli source code using TypeDoc:
+
+**Configuration:**
+- `typedoc.json` (if present) or inline in astro.config.mjs
+- Starlight-TypeDoc plugin integration
+- Markdown output format
+
+**Regeneration:**
+API docs are regenerated on each build automatically.
+
+## Styling and Theming
+
+### Custom Styles
+
+Add custom CSS in `src/styles/`:
+
+```css
+/* Custom theme overrides */
+:root {
+  --sl-color-accent: #your-color;
+}
+```
+
+### Fonts
+
+Custom fonts loaded via `@fontsource`:
+- `@fontsource/ibm-plex-serif`
+- `@fontsource/metropolis`
+- `@fontsource/open-sans`
+
+## Deployment
+
+### Netlify Deployment
+
+**Configuration:**
+- Output: `dist/` directory
+- Build command: `pnpm build:site`
+- Adapter: `@astrojs/netlify`
+
+**Automatic Deployment:**
+- Deploys on push to main branch
+- Preview builds for pull requests
+- Edge functions support
+
+### Build Validation
+
+Before deploying:
+
+```bash
+# Check Astro configuration
+pnpm check:astro
+
+# Build site
+pnpm build:site
+
+# Verify build output
+pnpm preview
+```
+
+## Plugin Configuration
+
+### Starlight Package Managers
+
+Enables package manager tabs for installation commands:
+
+```markdown
+```bash npm2yarn
+npm install dill-cli
+\```
+```
+
+Automatically generates tabs for npm, yarn, pnpm.
+
+### Starlight Links Validator
+
+Validates internal links during build:
+- Detects broken links
+- Warns about missing pages
+- Validates anchors
+
+### Starlight Heading Badges
+
+Add badges to headings:
+
+```markdown
+## New Feature {#new}
+```
+
+## Important Constraints
+
+1. **Part of Monorepo**: Uses `workspace:^` for dill-cli dependency
+2. **Auto-Generated Content**: Don't edit CLI reference manually
+3. **Astro Framework**: Follow Astro conventions
+4. **Starlight Theme**: Use Starlight-compatible markdown features
+5. **Static Site**: All content must be statically generated
+6. **Netlify Deployment**: Site deployed via Netlify adapter
+
+## Dependencies
+
+**Key Dependencies:**
+- `astro` - Framework
+- `@astrojs/starlight` - Documentation theme
+- `@astrojs/netlify` - Netlify adapter
+- `dill-cli` - Source for CLI reference (workspace dependency)
+- `typedoc` - API documentation generation
+
+**Starlight Plugins:**
+- `starlight-heading-badges`
+- `starlight-links-validator`
+- `starlight-package-managers`
+- `starlight-typedoc`
+
+## Common Tasks
+
+### Adding a New Page
+
+1. Create `src/content/docs/new-page.md`
+2. Add frontmatter with title and description
+3. Write content in Markdown
+4. Update navigation if needed (in astro.config.mjs)
+5. Test locally: `pnpm dev`
+6. Build: `pnpm build:site`
+
+### Updating CLI Reference
+
+```bash
+# Navigate to dill-cli package
+cd ../dill-cli
+
+# Regenerate README and docs
+pnpm build:readme
+
+# CLI reference in dill-docs is updated automatically
+```
+
+### Troubleshooting Build Issues
+
+```bash
+# Clear Astro cache
+pnpm clean
+
+# Check for configuration errors
+pnpm check:astro
+
+# Rebuild from scratch
+pnpm clean && pnpm build:site
+```
+
+## Related Packages
+
+- **dill-cli** - Source for CLI reference and API docs
+- **ccl-docs** - Similar documentation site structure
+- **repopo-docs** - Similar documentation site structure

--- a/packages/fundamentals/CLAUDE.md
+++ b/packages/fundamentals/CLAUDE.md
@@ -1,0 +1,304 @@
+# CLAUDE.md - @tylerbu/fundamentals
+
+Package-specific guidance for the fundamental utilities library.
+
+## Package Overview
+
+A collection of fundamental functions and classes commonly needed across projects. This library has **zero dependencies** and provides type-safe utilities for arrays, sets, git operations, and more.
+
+**Key Principle:** Zero runtime dependencies for maximum portability and minimal bundle size.
+
+## Essential Commands
+
+```bash
+# Install dependencies (dev only)
+pnpm install
+
+# Build the package
+pnpm build
+
+# Run tests
+pnpm test
+
+# Run tests with coverage
+pnpm test:coverage
+
+# Format code
+pnpm format
+
+# Lint code
+pnpm lint
+pnpm lint:fix  # Auto-fix issues
+
+# Generate API documentation
+pnpm build:api
+
+# Generate TypeDoc documentation
+pnpm build:docs
+
+# Clean build artifacts
+pnpm clean
+```
+
+## Module Structure
+
+The package provides multiple entry points for tree-shaking optimization:
+
+```typescript
+// Main entry (all utilities)
+import { /* ... */ } from "@tylerbu/fundamentals";
+
+// Git utilities only
+import { /* ... */ } from "@tylerbu/fundamentals/git";
+
+// Set utilities only
+import { /* ... */ } from "@tylerbu/fundamentals/set";
+```
+
+### Available Modules
+
+1. **Main Module** (`@tylerbu/fundamentals`)
+   - Array utilities
+   - String utilities
+   - Type utilities
+   - General-purpose functions
+
+2. **Git Module** (`@tylerbu/fundamentals/git`)
+   - Git repository operations
+   - Branch utilities
+   - Commit helpers
+
+3. **Set Module** (`@tylerbu/fundamentals/set`)
+   - Set operations (union, intersection, difference)
+   - Set utilities
+
+## Key Utilities
+
+### Array Utilities
+
+```typescript
+import { chunk, unique, groupBy } from "@tylerbu/fundamentals";
+
+// Split array into chunks
+const chunks = chunk([1, 2, 3, 4, 5], 2);
+// => [[1, 2], [3, 4], [5]]
+
+// Remove duplicates
+const uniqueItems = unique([1, 2, 2, 3, 3, 3]);
+// => [1, 2, 3]
+
+// Group by key
+const grouped = groupBy(
+  [{ type: "a", val: 1 }, { type: "b", val: 2 }],
+  item => item.type
+);
+// => Map { "a" => [{ type: "a", val: 1 }], "b" => [...] }
+```
+
+### Set Utilities
+
+```typescript
+import { union, intersection, difference } from "@tylerbu/fundamentals/set";
+
+const set1 = new Set([1, 2, 3]);
+const set2 = new Set([2, 3, 4]);
+
+// Union
+const u = union(set1, set2);
+// => Set { 1, 2, 3, 4 }
+
+// Intersection
+const i = intersection(set1, set2);
+// => Set { 2, 3 }
+
+// Difference
+const d = difference(set1, set2);
+// => Set { 1 }
+```
+
+### Git Utilities
+
+```typescript
+import { getCurrentBranch, isGitRepo } from "@tylerbu/fundamentals/git";
+
+// Check if directory is a git repo
+const isRepo = await isGitRepo("/path/to/dir");
+
+// Get current branch name
+const branch = await getCurrentBranch("/path/to/repo");
+```
+
+## Project Structure
+
+```
+packages/fundamentals/
+├── src/
+│   ├── index.ts           # Main exports
+│   ├── array.ts           # Array utilities
+│   ├── string.ts          # String utilities
+│   ├── git.ts             # Git utilities (separate export)
+│   ├── set.ts             # Set utilities (separate export)
+│   └── types.ts           # Type utilities
+├── esm/                   # Compiled output
+├── test/                  # Vitest tests
+├── _temp/                 # Generated API docs
+├── package.json
+└── tsconfig.json
+```
+
+## API Documentation
+
+### Generation
+
+The package uses **API Extractor** for multiple API documentation outputs:
+
+```bash
+# Generate all API docs
+pnpm build:api
+
+# Individual API configs:
+# - api-extractor.json (main)
+# - api-extractor.array.json
+# - api-extractor.git.json
+# - api-extractor.set.json
+```
+
+Each entry point has its own API Extractor configuration for modular documentation.
+
+### TypeDoc Documentation
+
+```bash
+# Generate TypeDoc markdown docs
+pnpm build:docs
+
+# Output: _temp/docs/ (or configured output directory)
+```
+
+## Testing Strategy
+
+Uses Vitest for comprehensive testing:
+
+```bash
+# Run all tests
+pnpm test
+
+# Run tests with coverage
+pnpm test:coverage
+
+# Watch mode
+pnpm test -- --watch
+```
+
+**Test Coverage Requirements:**
+- High coverage expected due to zero dependencies
+- All utility functions should have unit tests
+- Edge cases covered (empty arrays, null values, etc.)
+
+**Test Structure:**
+- Test files: `test/**/*.test.ts`
+- Coverage output: `.coverage/`
+
+## Design Principles
+
+1. **Zero Dependencies**
+   - No runtime dependencies
+   - Minimal dev dependencies
+   - Maximum portability
+
+2. **Tree-Shakable**
+   - Multiple entry points
+   - ES modules only
+   - Dead code elimination friendly
+
+3. **Type-Safe**
+   - Full TypeScript support
+   - Strict mode enabled
+   - Exported types for all utilities
+
+4. **Small Bundle Size**
+   - Pure functions
+   - No unnecessary abstractions
+   - Optimized for tree-shaking
+
+## Common Patterns
+
+### Adding New Utility Functions
+
+1. Create or update source file in `src/`
+2. Export from appropriate module (index.ts, git.ts, etc.)
+3. Add types and JSDoc comments
+4. Write tests in `test/`
+5. Update API Extractor config if adding new entry point
+6. Run `pnpm build:api` to generate docs
+7. Verify exports work correctly
+
+### Creating New Module Entry Point
+
+1. Create new source file (e.g., `src/newmodule.ts`)
+2. Add exports to `package.json`:
+   ```json
+   {
+     "exports": {
+       "./newmodule": {
+         "import": {
+           "types": "./esm/newmodule.d.ts",
+           "default": "./esm/newmodule.js"
+         }
+       }
+     }
+   }
+   ```
+3. Create API Extractor config: `api-extractor.newmodule.json`
+4. Update `build:api` script to include new config
+5. Document the new entry point
+
+## Used By
+
+This package is a foundational dependency used by:
+- **@tylerbu/cli-api** - CLI base classes
+- **@tylerbu/cli** - Personal CLI tool
+- **sort-tsconfig** - TypeScript config sorter
+- Other monorepo packages
+
+**Impact:** Changes to this package affect many downstream consumers. Ensure backward compatibility.
+
+## Important Constraints
+
+1. **Zero Runtime Dependencies** - Never add runtime dependencies
+2. **ES Modules Only** - No CommonJS support
+3. **TypeScript Strict Mode** - All code must pass strict checks
+4. **Tree-Shakable** - Keep utilities pure and modular
+5. **Biome Formatting** - Code must pass Biome checks
+6. **Test Coverage** - High coverage required for reliability
+
+## API Stability
+
+**Versioning:**
+- Follow semantic versioning
+- Breaking changes = major version bump
+- New utilities = minor version bump
+- Bug fixes = patch version bump
+
+**Deprecation:**
+- Mark deprecated with JSDoc `@deprecated`
+- Keep deprecated code for at least one major version
+- Document migration path in deprecation notice
+
+## Performance Considerations
+
+- All utilities are synchronous (except git operations)
+- No unnecessary allocations
+- Optimized for common use cases
+- Prefer native methods when available
+
+## Documentation
+
+**Inline Documentation:**
+- JSDoc comments for all exported functions
+- Include `@param`, `@returns`, `@example` tags
+- Document edge cases and limitations
+
+**Generated Documentation:**
+- API Extractor JSON (.api.json files)
+- TypeDoc markdown in `_temp/docs/`
+- Consumed by documentation sites

--- a/packages/levee-client/CLAUDE.md
+++ b/packages/levee-client/CLAUDE.md
@@ -1,0 +1,311 @@
+# CLAUDE.md - @tylerbu/levee-client
+
+Package-specific guidance for the Levee Fluid Framework service client.
+
+## Package Overview
+
+Client library for interacting with the Levee Fluid Framework service. This package provides a simplified interface for connecting to Fluid Framework containers and working with distributed data structures.
+
+**Status:** Private package (not published to npm)
+**Framework:** Fluid Framework v2.33.x
+**Purpose:** Personal projects using Fluid Framework
+
+## Essential Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the package
+pnpm build
+
+# Run tests
+pnpm test
+
+# Run tests with coverage
+pnpm test:coverage
+
+# Run tests (Mocha)
+pnpm test:mocha
+
+# Format code
+pnpm format
+
+# Lint code
+pnpm lint
+pnpm lint:fix  # Auto-fix issues
+
+# Generate API documentation
+pnpm build:api
+
+# Clean build artifacts
+pnpm clean
+
+# Start local Tinylicious server
+pnpm start
+
+# Stop local Tinylicious server
+pnpm stop
+```
+
+## Fluid Framework Basics
+
+### What is Fluid Framework?
+
+Fluid Framework is a collection of client libraries for building distributed, real-time collaborative applications. Key concepts:
+
+- **Container** - The top-level object that holds shared data
+- **DDSes** (Distributed Data Structures) - Shared data structures like maps, strings, sequences
+- **Service** - The backend service that synchronizes data (Tinylicious for local dev, Azure Fluid Relay for production)
+
+### Levee Service
+
+Levee is a custom Fluid Framework service configuration. This client package provides connection utilities and type definitions for working with Levee-hosted containers.
+
+## Project Structure
+
+```
+packages/levee-client/
+├── src/
+│   ├── index.ts              # Main exports
+│   ├── client.ts             # Client configuration
+│   ├── container.ts          # Container utilities
+│   └── types.ts              # Type definitions
+├── lib/                      # Compiled output (esm)
+├── test/                     # Tests (Mocha and Vitest)
+├── package.json
+└── tsconfig.json
+```
+
+## Key Exports
+
+### Client Connection
+
+```typescript
+import { createLeveeClient } from "@tylerbu/levee-client";
+
+// Create Fluid client connected to Levee service
+const client = createLeveeClient({
+  serviceUrl: "https://levee.example.com",
+  userId: "user123",
+  userName: "User Name"
+});
+```
+
+### Container Operations
+
+```typescript
+import { getContainer, createContainer } from "@tylerbu/levee-client";
+
+// Get existing container
+const container = await getContainer(client, containerId);
+
+// Create new container
+const { container, services } = await createContainer(client, containerSchema);
+```
+
+### Shared Objects
+
+```typescript
+import { SharedMap } from "@fluidframework/map";
+
+// Access shared data structures from container
+const myMap = await container.getSharedObject<SharedMap>("myMapId");
+
+// Listen to changes
+myMap.on("valueChanged", (changed, local) => {
+  console.log(`Value changed: ${changed.key}`);
+});
+
+// Set values
+myMap.set("key", "value");
+```
+
+## Testing Strategy
+
+### Local Testing with Tinylicious
+
+Tinylicious is a local Fluid service for development:
+
+```bash
+# Start Tinylicious server
+pnpm start
+
+# Server runs on http://localhost:7070
+
+# Run tests against local server
+pnpm test
+
+# Stop server
+pnpm stop
+```
+
+### Unit Tests
+
+Two test frameworks supported:
+
+**Vitest:**
+```bash
+pnpm test:vitest
+```
+
+**Mocha:**
+```bash
+pnpm test:mocha
+```
+
+### Test Structure
+
+- Unit tests in `test/` directory
+- Integration tests require running Tinylicious
+- Use `@fluidframework/test-utils` for test helpers
+
+## Fluid Framework Dependencies
+
+**Core Packages:**
+- `@fluidframework/container-loader` - Container loading
+- `@fluidframework/fluid-static` - Simplified API
+- `@fluidframework/map` - SharedMap DDS
+- `@fluidframework/routerlicious-driver` - Azure driver
+- `@fluidframework/tinylicious-driver` - Local dev driver
+
+**Version Pinning:**
+All Fluid Framework packages are pinned to `~2.33.2` for consistency.
+
+## Development Workflow
+
+### Connecting to Local Service
+
+```typescript
+import { TinyliciousClient } from "@fluidframework/tinylicious-client";
+
+// For local development
+const client = new TinyliciousClient();
+```
+
+### Connecting to Production Service
+
+```typescript
+import { AzureClient } from "@fluidframework/azure-client";
+
+// For production (Azure Fluid Relay)
+const client = new AzureClient({
+  connection: {
+    type: "remote",
+    tenantId: "...",
+    tokenProvider: ...
+  }
+});
+```
+
+## Common Patterns
+
+### Creating a Container Schema
+
+```typescript
+import { ContainerSchema } from "@fluidframework/fluid-static";
+import { SharedMap } from "@fluidframework/map";
+
+const containerSchema: ContainerSchema = {
+  initialObjects: {
+    myMap: SharedMap,
+  },
+};
+
+const { container } = await client.createContainer(containerSchema);
+```
+
+### Working with Shared Maps
+
+```typescript
+const map = container.initialObjects.myMap;
+
+// Set values
+map.set("counter", 0);
+
+// Get values
+const value = map.get("counter");
+
+// Listen to changes
+map.on("valueChanged", (changed) => {
+  console.log(`Key: ${changed.key}, Value: ${map.get(changed.key)}`);
+});
+
+// Increment (collaborative counter example)
+map.set("counter", (map.get("counter") || 0) + 1);
+```
+
+### Handling Container Events
+
+```typescript
+// Connection state changes
+container.on("connected", () => {
+  console.log("Connected to service");
+});
+
+container.on("disconnected", () => {
+  console.log("Disconnected from service");
+});
+
+// Errors
+container.on("closed", (error) => {
+  console.error("Container closed", error);
+});
+```
+
+## Important Constraints
+
+1. **Private Package** - Not published to npm
+2. **Fluid Framework Version** - Locked to v2.33.x
+3. **TypeScript** - Strict mode enabled
+4. **Local Development** - Requires Tinylicious server
+5. **Biome Formatting** - Code must pass Biome checks
+6. **Test Coverage** - Both Vitest and Mocha supported
+
+## Fluid Framework Resources
+
+**Official Documentation:**
+- https://fluidframework.com/docs/
+- https://github.com/microsoft/FluidFramework
+
+**Key Concepts:**
+- DDSes (Distributed Data Structures)
+- Container lifecycle
+- Service connection patterns
+- Collaboration patterns
+
+## Troubleshooting
+
+### Connection Issues
+
+```bash
+# Verify Tinylicious is running
+curl http://localhost:7070
+
+# Check logs
+pnpm start  # View server logs
+```
+
+### Version Conflicts
+
+Fluid Framework requires all packages at the same version:
+
+```bash
+# Check for version mismatches
+pnpm list | grep @fluidframework
+
+# Update all Fluid packages together
+pnpm update @fluidframework/*
+```
+
+### Type Errors
+
+Ensure all `@fluidframework` packages are at compatible versions. The framework uses strict version alignment.
+
+## Future Considerations
+
+- Consider upgrading to latest Fluid Framework version
+- Evaluate Azure Fluid Relay for production
+- Add more DDS examples (SharedString, SharedTree)
+- Improve error handling and reconnection logic
+- Add telemetry and monitoring

--- a/packages/lilconfig-loader-ts/CLAUDE.md
+++ b/packages/lilconfig-loader-ts/CLAUDE.md
@@ -1,0 +1,307 @@
+# CLAUDE.md - @tylerbu/lilconfig-loader-ts
+
+Package-specific guidance for the lilconfig TypeScript loader.
+
+## Package Overview
+
+A loader that enables loading TypeScript configuration files in lilconfig. This utility allows projects using lilconfig to support TypeScript config files (`.ts`, `.mts`, `.cts`) alongside standard JavaScript and JSON formats.
+
+**Purpose:** Enable TypeScript config files in lilconfig-based applications
+**Implementation:** Uses `jiti` for JIT TypeScript compilation
+**Peer Dependency:** Requires `lilconfig` v3.1.3+
+
+## Essential Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the package
+pnpm build
+
+# Format code
+pnpm format
+
+# Lint code
+pnpm lint
+pnpm lint:fix  # Auto-fix issues
+
+# Check formatting
+pnpm check
+
+# Generate API documentation
+pnpm build:api
+
+# Clean build artifacts
+pnpm clean
+```
+
+## Usage
+
+### Basic Usage
+
+```typescript
+import { lilconfig } from "lilconfig";
+import { loaders } from "@tylerbu/lilconfig-loader-ts";
+
+// Create config loader with TypeScript support
+const explorer = lilconfig("myapp", {
+  loaders: {
+    ".ts": loaders.ts,
+    ".mts": loaders.mts,
+    ".cts": loaders.cts,
+  },
+});
+
+// Now supports these config files:
+// - myapp.config.ts
+// - myapp.config.mts
+// - myapp.config.cts
+const result = await explorer.search();
+```
+
+### Integration Example
+
+```typescript
+import { lilconfig } from "lilconfig";
+import { loaders } from "@tylerbu/lilconfig-loader-ts";
+
+export async function loadConfig() {
+  const explorer = lilconfig("myapp", {
+    searchPlaces: [
+      "package.json",
+      ".myapprc",
+      ".myapprc.json",
+      ".myapprc.yaml",
+      ".myapprc.yml",
+      "myapp.config.js",
+      "myapp.config.cjs",
+      "myapp.config.mjs",
+      "myapp.config.ts",  // TypeScript support!
+    ],
+    loaders: {
+      ".ts": loaders.ts,
+      ".mts": loaders.mts,
+      ".cts": loaders.cts,
+    },
+  });
+
+  return await explorer.search();
+}
+```
+
+## How It Works
+
+### Under the Hood
+
+The loader uses `jiti` for just-in-time TypeScript compilation:
+
+```typescript
+import { createJiti } from "jiti";
+
+// Creates a JIT loader that compiles TypeScript on-the-fly
+const loader = (filepath: string) => {
+  const jiti = createJiti(filepath, {
+    interopDefault: true,  // Handle default exports
+    moduleCache: false,    // Fresh compilation each time
+  });
+  return jiti(filepath);
+};
+```
+
+**Key Features:**
+- No build step required for config files
+- Supports all TypeScript features
+- Handles ES modules and CommonJS
+- Automatic default export handling
+
+### Supported Extensions
+
+- `.ts` - TypeScript files
+- `.mts` - TypeScript ES modules
+- `.cts` - TypeScript CommonJS modules
+
+## Project Structure
+
+```
+packages/lilconfig-loader-ts/
+├── src/
+│   └── index.ts           # Loader implementation
+├── esm/                   # Compiled output
+├── _temp/                 # API documentation
+├── package.json
+└── tsconfig.json
+```
+
+## Configuration File Examples
+
+### TypeScript Config
+
+```typescript
+// myapp.config.ts
+import type { MyAppConfig } from "myapp";
+
+const config: MyAppConfig = {
+  option1: "value1",
+  option2: 42,
+};
+
+export default config;
+```
+
+### ES Module TypeScript
+
+```typescript
+// myapp.config.mts
+export default {
+  option1: "value1",
+  option2: 42,
+};
+```
+
+### CommonJS TypeScript
+
+```typescript
+// myapp.config.cts
+module.exports = {
+  option1: "value1",
+  option2: 42,
+};
+```
+
+## Used By
+
+This package is used by:
+- **@tylerbu/cli-api** - CLI configuration loading
+- Any package using lilconfig that wants TypeScript config support
+
+## Common Patterns
+
+### Type-Safe Configuration
+
+```typescript
+// Define config type
+export interface MyAppConfig {
+  setting1: string;
+  setting2: number;
+  advanced?: {
+    debug: boolean;
+  };
+}
+
+// Use in config file (myapp.config.ts)
+import type { MyAppConfig } from "./types";
+
+const config: MyAppConfig = {
+  setting1: "value",
+  setting2: 42,
+  advanced: {
+    debug: true,
+  },
+};
+
+export default config;
+```
+
+### Dynamic Configuration
+
+```typescript
+// myapp.config.ts
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+
+// Load additional data
+const data = parse(readFileSync("./data.yaml", "utf-8"));
+
+export default {
+  setting1: data.value,
+  setting2: process.env.MY_VAR ?? "default",
+};
+```
+
+### Conditional Configuration
+
+```typescript
+// myapp.config.ts
+const isDev = process.env.NODE_ENV === "development";
+
+export default {
+  debug: isDev,
+  apiUrl: isDev
+    ? "http://localhost:3000"
+    : "https://api.example.com",
+};
+```
+
+## Important Constraints
+
+1. **Peer Dependency** - Requires lilconfig v3.1.3+
+2. **JIT Compilation** - Uses jiti for runtime TypeScript compilation
+3. **ES Modules** - Package is ES module only
+4. **TypeScript Support** - Supports all TypeScript features
+5. **Biome Formatting** - Code must pass Biome checks
+
+## Dependencies
+
+**Runtime:**
+- `jiti` - Just-in-time TypeScript/ESM loader
+
+**Peer Dependencies:**
+- `lilconfig` v3.1.3+ - Configuration file loader
+
+**Dev Dependencies:**
+- Standard TypeScript tooling
+- API Extractor for documentation
+
+## Performance Considerations
+
+### JIT Compilation Overhead
+
+- TypeScript files compiled at runtime (not ahead of time)
+- Adds small startup cost (typically <100ms)
+- Compiled output not cached by default
+- Consider using JavaScript config files in performance-critical scenarios
+
+### Optimization Tips
+
+1. **Keep configs simple** - Avoid heavy computations in config files
+2. **Cache results** - Cache loaded config in your application
+3. **Precompile for production** - Consider transpiling TS configs to JS
+
+## Alternatives
+
+### Transpile Manually
+
+Instead of runtime compilation:
+
+```bash
+# Transpile TypeScript config to JavaScript
+tsc myapp.config.ts --outDir .
+
+# Use transpiled version
+```
+
+### Use JavaScript
+
+For maximum performance, use JavaScript config files:
+
+```javascript
+// myapp.config.js
+export default {
+  setting1: "value",
+  setting2: 42,
+};
+```
+
+## Future Enhancements
+
+- Add caching for compiled configs
+- Support source maps for better error messages
+- Add watch mode for config file changes
+- Consider alternative loaders (esbuild-register, tsx)
+
+## Related Packages
+
+- **lilconfig** - Configuration file loader (peer dependency)
+- **jiti** - JIT TypeScript compiler (runtime dependency)
+- **@tylerbu/cli-api** - Consumer of this loader

--- a/packages/rehype-footnotes/CLAUDE.md
+++ b/packages/rehype-footnotes/CLAUDE.md
@@ -1,0 +1,333 @@
+# CLAUDE.md - rehype-footnotes
+
+Package-specific guidance for the rehype footnotes plugin.
+
+## Package Overview
+
+Rehype plugin to transform GitHub Flavored Markdown (GFM) footnotes for Littlefoot.js integration. This plugin modifies the HTML structure of footnotes to work with Littlefoot's popover footnote library.
+
+**Plugin Type:** Rehype (HTML transformer)
+**Use Case:** Convert GFM footnotes to Littlefoot-compatible format
+**Peer Dependency:** Requires `unified` v11+
+
+## Essential Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the package
+pnpm build
+
+# Run tests
+pnpm test
+
+# Run tests with coverage
+pnpm test:coverage
+
+# Format code
+pnpm format
+
+# Lint code
+pnpm lint
+pnpm lint:fix  # Auto-fix issues
+
+# Clean build artifacts
+pnpm clean
+```
+
+## Usage
+
+### Basic Usage
+
+```typescript
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import remarkRehype from "remark-rehype";
+import rehypeFootnotes from "rehype-footnotes";
+import rehypeStringify from "rehype-stringify";
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkGfm)          // GFM support (includes footnotes)
+  .use(remarkRehype)
+  .use(rehypeFootnotes)    // Transform footnotes for Littlefoot
+  .use(rehypeStringify);
+
+const result = await processor.process(markdown);
+```
+
+### In Astro/Starlight
+
+```typescript
+// astro.config.mjs
+import rehypeFootnotes from "rehype-footnotes";
+
+export default {
+  markdown: {
+    rehypePlugins: [
+      rehypeFootnotes,
+    ],
+  },
+};
+```
+
+### With Remark
+
+```typescript
+import { remark } from "remark";
+import remarkGfm from "remark-gfm";
+import remarkRehype from "remark-rehype";
+import rehypeFootnotes from "rehype-footnotes";
+
+const result = await remark()
+  .use(remarkGfm)
+  .use(remarkRehype)
+  .use(rehypeFootnotes)
+  .process(markdown);
+```
+
+## What It Does
+
+### GFM Footnote Syntax
+
+```markdown
+Here is a sentence with a footnote[^1].
+
+[^1]: This is the footnote content.
+```
+
+### Default GFM Output
+
+```html
+<p>Here is a sentence with a footnote<sup><a href="#fn-1" id="fnref-1">1</a></sup>.</p>
+
+<section data-footnotes>
+  <ol>
+    <li id="fn-1">
+      <p>This is the footnote content. <a href="#fnref-1">↩</a></p>
+    </li>
+  </ol>
+</section>
+```
+
+### After rehype-footnotes Transform
+
+```html
+<p>Here is a sentence with a footnote<sup><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup>.</p>
+
+<section data-footnotes class="footnotes">
+  <ol>
+    <li id="fn-1">
+      <p>This is the footnote content.</p>
+      <a href="#fnref-1" data-footnote-backref>↩</a>
+    </li>
+  </ol>
+</section>
+```
+
+**Key Changes:**
+- Adds `data-footnote-ref` attribute to footnote references
+- Adds `data-footnote-backref` attribute to back-references
+- Adds `footnotes` class to footnotes section
+- Restructures backref links for Littlefoot compatibility
+
+## Integration with Littlefoot.js
+
+### Setup
+
+```html
+<!-- Include Littlefoot CSS and JS -->
+<link rel="stylesheet" href="littlefoot.css">
+<script src="littlefoot.js"></script>
+
+<script>
+  // Initialize Littlefoot
+  littlefoot.littlefoot({
+    activateOnHover: true,
+    allowDuplicates: true,
+  });
+</script>
+```
+
+### Result
+
+Footnotes appear as popover tooltips when hovering/clicking the footnote number, instead of jumping to the bottom of the page.
+
+## Project Structure
+
+```
+packages/rehype-footnotes/
+├── src/
+│   └── index.ts           # Plugin implementation
+├── esm/                   # Compiled output
+├── test/                  # Vitest tests
+│   └── index.test.ts
+├── package.json
+└── tsconfig.json
+```
+
+## Plugin Implementation
+
+### Core Logic
+
+```typescript
+import { visit } from "unist-util-visit";
+import type { Plugin } from "unified";
+import type { Root } from "hast";
+
+const rehypeFootnotes: Plugin<[], Root> = () => {
+  return (tree) => {
+    visit(tree, "element", (node) => {
+      // Transform footnote references
+      if (isFootnoteRef(node)) {
+        node.properties.dataFootnoteRef = true;
+      }
+
+      // Transform footnote back-references
+      if (isFootnoteBackref(node)) {
+        node.properties.dataFootnoteBackref = true;
+      }
+
+      // Add class to footnotes section
+      if (isFootnotesSection(node)) {
+        node.properties.className = "footnotes";
+      }
+    });
+  };
+};
+```
+
+## Testing Strategy
+
+Uses Vitest with remark/rehype test utilities:
+
+```bash
+# Run tests
+pnpm test
+
+# Watch mode
+pnpm test -- --watch
+
+# Coverage
+pnpm test:coverage
+```
+
+**Test Structure:**
+- Input: Markdown with GFM footnotes
+- Process: remark-gfm → remark-rehype → rehype-footnotes
+- Output: Verify HTML structure with correct attributes
+
+**Example Test:**
+```typescript
+import { test, expect } from "vitest";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import remarkRehype from "remark-rehype";
+import rehypeFootnotes from "../src/index.js";
+import rehypeStringify from "rehype-stringify";
+
+test("transforms footnotes for Littlefoot", async () => {
+  const input = "Text[^1].\n\n[^1]: Footnote.";
+
+  const result = await unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkRehype)
+    .use(rehypeFootnotes)
+    .use(rehypeStringify)
+    .process(input);
+
+  expect(result.toString()).toContain('data-footnote-ref');
+  expect(result.toString()).toContain('data-footnote-backref');
+  expect(result.toString()).toContain('class="footnotes"');
+});
+```
+
+## Common Use Cases
+
+### Astro Blog
+
+```typescript
+// astro.config.mjs
+import { defineConfig } from "astro/config";
+import rehypeFootnotes from "rehype-footnotes";
+
+export default defineConfig({
+  markdown: {
+    remarkPlugins: [
+      "remark-gfm",
+    ],
+    rehypePlugins: [
+      rehypeFootnotes,
+    ],
+  },
+});
+```
+
+### Static Site Generator
+
+```typescript
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import remarkRehype from "remark-rehype";
+import rehypeFootnotes from "rehype-footnotes";
+import rehypeStringify from "rehype-stringify";
+
+async function processMarkdown(markdown: string) {
+  return unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkRehype)
+    .use(rehypeFootnotes)
+    .use(rehypeStringify)
+    .process(markdown);
+}
+```
+
+## Important Constraints
+
+1. **GFM Required** - Requires remark-gfm for footnote syntax support
+2. **Peer Dependency** - Requires unified v11+
+3. **HTML Transform** - Operates on HTML (rehype), not Markdown (remark)
+4. **Littlefoot Target** - Designed specifically for Littlefoot.js
+5. **TypeScript** - Strict mode enabled
+6. **Biome Formatting** - Code must pass Biome checks
+
+## Dependencies
+
+**Runtime:**
+- `unified` - Unified text processing framework (peer dependency)
+- `unist-util-visit` - AST visitor utility
+
+**Dev Dependencies:**
+- `rehype` - HTML processor
+- `remark` - Markdown processor
+- `remark-gfm` - GitHub Flavored Markdown support
+- `remark-rehype` - Markdown to HTML bridge
+- `vitest` - Testing framework
+
+## Alternatives
+
+### Other Footnote Solutions
+
+1. **Native GFM** - Use default GFM footnotes (no popover)
+2. **Custom CSS** - Style footnotes with CSS only
+3. **Other Plugins** - rehype-footnote-titles, remark-footnotes
+4. **Manual HTML** - Write footnotes directly in HTML
+
+## Future Enhancements
+
+- Support configuration options
+- Add support for other footnote libraries
+- Improve accessibility attributes
+- Add support for multiple footnote formats
+
+## Related Packages
+
+- **remark-lazy-links** - Sister remark plugin
+- **remark-shift-headings** - Sister remark plugin
+- **Littlefoot.js** - Target library for footnote popovers

--- a/packages/remark-lazy-links/CLAUDE.md
+++ b/packages/remark-lazy-links/CLAUDE.md
@@ -1,0 +1,354 @@
+# CLAUDE.md - remark-lazy-links
+
+Package-specific guidance for the remark lazy links plugin.
+
+## Package Overview
+
+Remark plugin to transform lazy markdown links `[*]` into numbered references. This plugin simplifies writing markdown with many links by allowing you to use `[*]` as a placeholder and automatically generating sequential reference numbers.
+
+**Plugin Type:** Remark (Markdown transformer)
+**Use Case:** Simplify link authoring in markdown
+**Peer Dependency:** Requires `unified` v11+
+
+## Essential Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the package
+pnpm build
+
+# Run tests
+pnpm test
+
+# Run tests with coverage
+pnpm test:coverage
+
+# Format code
+pnpm format
+
+# Lint code
+pnpm lint
+pnpm lint:fix  # Auto-fix issues
+
+# Clean build artifacts
+pnpm clean
+```
+
+## Usage
+
+### Basic Usage
+
+```typescript
+import { remark } from "remark";
+import remarkLazyLinks from "remark-lazy-links";
+
+const result = await remark()
+  .use(remarkLazyLinks)
+  .process(markdown);
+```
+
+### In Astro/Starlight
+
+```typescript
+// astro.config.mjs
+import remarkLazyLinks from "remark-lazy-links";
+
+export default {
+  markdown: {
+    remarkPlugins: [
+      remarkLazyLinks,
+    ],
+  },
+};
+```
+
+### With Unified Pipeline
+
+```typescript
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkLazyLinks from "remark-lazy-links";
+import remarkStringify from "remark-stringify";
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkLazyLinks)
+  .use(remarkStringify);
+
+const result = await processor.process(markdown);
+```
+
+## What It Does
+
+### Input Markdown
+
+```markdown
+This is a sentence with a [*].
+
+And another sentence with a [*].
+
+[*]: https://example.com
+[*]: https://example.org
+```
+
+### Output Markdown
+
+```markdown
+This is a sentence with a [1].
+
+And another sentence with a [2].
+
+[1]: https://example.com
+[2]: https://example.org
+```
+
+**Transformation:**
+- Replaces `[*]` with sequential numbers `[1]`, `[2]`, etc.
+- Updates corresponding reference definitions
+- Maintains link functionality
+
+### Why Use Lazy Links?
+
+**Benefits:**
+- Faster writing - don't think about numbering
+- Easy reordering - no manual renumbering needed
+- Less cognitive load - focus on content, not numbers
+- Automatic consistency - plugin ensures correct numbering
+
+**Use Cases:**
+- Blog posts with many links
+- Documentation with frequent citations
+- Academic writing
+- Technical articles
+
+## How It Works
+
+### Algorithm
+
+1. **First Pass** - Find all `[*]` link references and `[*]:` definitions
+2. **Number Assignment** - Assign sequential numbers starting from 1
+3. **AST Transform** - Update markdown AST nodes with numbers
+4. **Order Preservation** - Maintain document order
+
+### Implementation Details
+
+```typescript
+import { visit } from "mdast-util-from-markdown";
+import type { Plugin } from "unified";
+import type { Root } from "mdast";
+
+const remarkLazyLinks: Plugin<[], Root> = () => {
+  return (tree, file) => {
+    let counter = 1;
+
+    // First pass: collect all lazy links
+    const lazyLinks: Array<Node> = [];
+
+    visit(tree, "linkReference", (node) => {
+      if (node.label === "*") {
+        lazyLinks.push(node);
+      }
+    });
+
+    // Second pass: assign numbers
+    for (const link of lazyLinks) {
+      link.label = String(counter);
+      link.identifier = String(counter);
+      counter++;
+    }
+
+    // Third pass: update definitions
+    counter = 1;
+    visit(tree, "definition", (node) => {
+      if (node.label === "*") {
+        node.label = String(counter);
+        node.identifier = String(counter);
+        counter++;
+      }
+    });
+  };
+};
+```
+
+## Project Structure
+
+```
+packages/remark-lazy-links/
+├── src/
+│   └── index.ts           # Plugin implementation
+├── esm/                   # Compiled output
+├── test/                  # Vitest tests
+│   └── index.test.ts
+├── package.json
+└── tsconfig.json
+```
+
+## Testing Strategy
+
+Uses Vitest with remark test utilities:
+
+```bash
+# Run tests
+pnpm test
+
+# Watch mode
+pnpm test -- --watch
+
+# Coverage
+pnpm test:coverage
+```
+
+**Test Cases:**
+- Single lazy link
+- Multiple lazy links
+- Mixed lazy and numbered links
+- Lazy links without definitions
+- Edge cases (empty document, etc.)
+
+**Example Test:**
+```typescript
+import { test, expect } from "vitest";
+import { remark } from "remark";
+import remarkLazyLinks from "../src/index.js";
+
+test("transforms lazy links to numbered references", async () => {
+  const input = "Link [*] and [*].\n\n[*]: https://a.com\n[*]: https://b.com";
+
+  const result = await remark()
+    .use(remarkLazyLinks)
+    .process(input);
+
+  expect(result.toString()).toContain("[1]");
+  expect(result.toString()).toContain("[2]");
+  expect(result.toString()).toContain("[1]: https://a.com");
+  expect(result.toString()).toContain("[2]: https://b.com");
+});
+```
+
+## Common Use Cases
+
+### Blog Writing
+
+```markdown
+I recently discovered [*] which is similar to [*].
+Both are mentioned in [*].
+
+[*]: https://tool1.com
+[*]: https://tool2.com
+[*]: https://comparison-article.com
+```
+
+Becomes:
+
+```markdown
+I recently discovered [1] which is similar to [2].
+Both are mentioned in [3].
+
+[1]: https://tool1.com
+[2]: https://tool2.com
+[3]: https://comparison-article.com
+```
+
+### Documentation
+
+```markdown
+See the [*] for more details. Also check out [*] and [*].
+
+[*]: https://docs.example.com/intro
+[*]: https://docs.example.com/advanced
+[*]: https://docs.example.com/api
+```
+
+### Academic Citations
+
+```markdown
+According to recent studies [*], the method is effective.
+Previous work [*] showed similar results.
+
+[*]: https://journal.com/paper1
+[*]: https://journal.com/paper2
+```
+
+## Advanced Usage
+
+### Mixed Links
+
+The plugin works alongside regular numbered links:
+
+```markdown
+Regular link [1] and lazy links [*] and [*].
+
+[1]: https://regular.com
+[*]: https://lazy1.com
+[*]: https://lazy2.com
+```
+
+Becomes:
+
+```markdown
+Regular link [1] and lazy links [2] and [3].
+
+[1]: https://regular.com
+[2]: https://lazy1.com
+[3]: https://lazy2.com
+```
+
+### Integration with Other Plugins
+
+```typescript
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkLazyLinks from "remark-lazy-links";
+import remarkGfm from "remark-gfm";
+import remarkRehype from "remark-rehype";
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .use(remarkLazyLinks)  // Transform before converting to HTML
+  .use(remarkRehype);
+```
+
+## Important Constraints
+
+1. **Peer Dependency** - Requires unified v11+
+2. **Markdown Transform** - Operates on Markdown AST (mdast)
+3. **Sequential Numbering** - Always starts from 1
+4. **Document Order** - Numbers assigned in document order
+5. **TypeScript** - Strict mode enabled
+6. **Biome Formatting** - Code must pass Biome checks
+
+## Dependencies
+
+**Runtime:**
+- `unified` - Unified text processing framework (peer dependency)
+- `mdast-util-from-markdown` - Markdown AST utilities
+- `vfile` - Virtual file abstraction
+
+**Dev Dependencies:**
+- `remark` - Markdown processor
+- `remark-parse` - Markdown parser
+- `vitest` - Testing framework
+
+## Limitations
+
+1. **No Custom Numbering** - Always uses 1, 2, 3, ...
+2. **No Grouping** - All lazy links numbered sequentially
+3. **No Reset** - Counter doesn't reset within document
+4. **Order Dependent** - Numbering based on document order
+
+## Future Enhancements
+
+- Support custom number starting point
+- Support alpha numbering (a, b, c)
+- Support grouped numbering
+- Add configuration options
+- Support named lazy links `[*topic1]`, `[*topic2]`
+
+## Related Packages
+
+- **rehype-footnotes** - Sister rehype plugin
+- **remark-shift-headings** - Sister remark plugin
+- **remark-gfm** - Often used together

--- a/packages/remark-shift-headings/CLAUDE.md
+++ b/packages/remark-shift-headings/CLAUDE.md
@@ -1,0 +1,435 @@
+# CLAUDE.md - remark-shift-headings
+
+Package-specific guidance for the remark shift headings plugin.
+
+## Package Overview
+
+Remark plugin to shift heading levels based on rendering context. This plugin adjusts heading levels (h1→h2, h2→h3, etc.) to maintain proper document hierarchy when embedding markdown content in different contexts.
+
+**Plugin Type:** Remark (Markdown transformer)
+**Use Case:** Adjust heading levels for content reuse
+**Peer Dependency:** Requires `unified` v11+
+
+## Essential Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the package
+pnpm build
+
+# Run tests
+pnpm test
+
+# Run tests with coverage
+pnpm test:coverage
+
+# Format code
+pnpm format
+
+# Lint code
+pnpm lint
+pnpm lint:fix  # Auto-fix issues
+
+# Clean build artifacts
+pnpm clean
+```
+
+## Usage
+
+### Basic Usage
+
+```typescript
+import { remark } from "remark";
+import remarkShiftHeadings from "remark-shift-headings";
+
+// Shift all headings down by 1 level
+const result = await remark()
+  .use(remarkShiftHeadings, { shift: 1 })
+  .process(markdown);
+```
+
+### Configuration Options
+
+```typescript
+interface ShiftHeadingsOptions {
+  shift: number;  // Number of levels to shift (positive = down, negative = up)
+}
+
+// Shift down 2 levels (h1 → h3, h2 → h4)
+.use(remarkShiftHeadings, { shift: 2 })
+
+// Shift up 1 level (h2 → h1, h3 → h2)
+.use(remarkShiftHeadings, { shift: -1 })
+```
+
+### In Astro/Starlight
+
+```typescript
+// astro.config.mjs
+import remarkShiftHeadings from "remark-shift-headings";
+
+export default {
+  markdown: {
+    remarkPlugins: [
+      [remarkShiftHeadings, { shift: 1 }],
+    ],
+  },
+};
+```
+
+### With Unified Pipeline
+
+```typescript
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkShiftHeadings from "remark-shift-headings";
+import remarkStringify from "remark-stringify";
+
+const processor = unified()
+  .use(remarkParse)
+  .use(remarkShiftHeadings, { shift: 1 })
+  .use(remarkStringify);
+
+const result = await processor.process(markdown);
+```
+
+## What It Does
+
+### Input Markdown
+
+```markdown
+# Main Title
+
+## Section
+
+### Subsection
+
+#### Detail
+```
+
+### Output with `shift: 1`
+
+```markdown
+## Main Title
+
+### Section
+
+#### Subsection
+
+##### Detail
+```
+
+### Output with `shift: -1`
+
+```markdown
+(h1 stays h1 - minimum level)
+
+# Section
+
+## Subsection
+
+### Detail
+```
+
+**Rules:**
+- Positive shift: Increase heading levels (h1→h2, h2→h3)
+- Negative shift: Decrease heading levels (h3→h2, h2→h1)
+- Minimum level: h1 (headings don't go below h1)
+- Maximum level: h6 (headings don't go beyond h6)
+
+## Use Cases
+
+### Content Reuse
+
+**Problem:** You have a markdown document that starts with h1, but you want to embed it in a page that already has an h1:
+
+```markdown
+<!-- Main page -->
+# My Website
+
+<!-- Embedded content starts with h1 -->
+# Article Title
+
+## Article Section
+```
+
+**Solution:** Shift embedded content down:
+
+```markdown
+# My Website
+
+## Article Title
+
+### Article Section
+```
+
+### Component-Based Documentation
+
+```typescript
+// Render markdown component with adjusted headings
+function MarkdownComponent({ content, level }: Props) {
+  const processor = remark()
+    .use(remarkShiftHeadings, { shift: level })
+    .use(remarkRehype)
+    .use(rehypeStringify);
+
+  return processor.process(content);
+}
+
+// Use h1 in source, but render as h3 in context
+<MarkdownComponent content={articleMd} level={2} />
+```
+
+### Multi-Level Content
+
+```typescript
+// Top-level page (no shift)
+const pageContent = await processMarkdown(md, 0);
+
+// Section content (shift down 1)
+const sectionContent = await processMarkdown(md, 1);
+
+// Subsection content (shift down 2)
+const subsectionContent = await processMarkdown(md, 2);
+```
+
+### API Documentation
+
+Embedding API docs with proper heading hierarchy:
+
+```typescript
+// Main docs page has h1
+// API reference should start at h2
+const apiDocs = await remark()
+  .use(remarkShiftHeadings, { shift: 1 })
+  .process(apiMarkdown);
+```
+
+## Project Structure
+
+```
+packages/remark-shift-headings/
+├── src/
+│   └── index.ts           # Plugin implementation
+├── esm/                   # Compiled output
+├── test/                  # Vitest tests
+│   └── index.test.ts
+├── package.json
+└── tsconfig.json
+```
+
+## Plugin Implementation
+
+### Core Logic
+
+```typescript
+import { visit } from "unist-util-visit";
+import type { Plugin } from "unified";
+import type { Root, Heading } from "mdast";
+
+interface Options {
+  shift: number;
+}
+
+const remarkShiftHeadings: Plugin<[Options?], Root> = (options = { shift: 0 }) => {
+  return (tree) => {
+    visit(tree, "heading", (node: Heading) => {
+      let newDepth = node.depth + options.shift;
+
+      // Clamp to valid range (1-6)
+      newDepth = Math.max(1, Math.min(6, newDepth));
+
+      node.depth = newDepth as 1 | 2 | 3 | 4 | 5 | 6;
+    });
+  };
+};
+
+export default remarkShiftHeadings;
+```
+
+## Testing Strategy
+
+Uses Vitest with remark test utilities:
+
+```bash
+# Run tests
+pnpm test
+
+# Watch mode
+pnpm test -- --watch
+
+# Coverage
+pnpm test:coverage
+```
+
+**Test Cases:**
+- Shift down by 1
+- Shift down by 2+
+- Shift up by 1
+- Shift up with clamping at h1
+- Shift down with clamping at h6
+- No shift (identity)
+- Edge cases
+
+**Example Test:**
+```typescript
+import { test, expect } from "vitest";
+import { remark } from "remark";
+import remarkShiftHeadings from "../src/index.js";
+
+test("shifts headings down by 1 level", async () => {
+  const input = "# Title\n\n## Section\n\n### Subsection";
+
+  const result = await remark()
+    .use(remarkShiftHeadings, { shift: 1 })
+    .process(input);
+
+  const output = result.toString();
+  expect(output).toContain("## Title");
+  expect(output).toContain("### Section");
+  expect(output).toContain("#### Subsection");
+});
+
+test("clamps at h1 minimum", async () => {
+  const input = "## Section";
+
+  const result = await remark()
+    .use(remarkShiftHeadings, { shift: -2 })
+    .process(input);
+
+  expect(result.toString()).toContain("# Section");
+});
+
+test("clamps at h6 maximum", async () => {
+  const input = "###### Deep";
+
+  const result = await remark()
+    .use(remarkShiftHeadings, { shift: 2 })
+    .process(input);
+
+  expect(result.toString()).toContain("###### Deep");
+});
+```
+
+## Advanced Usage
+
+### Dynamic Shifting Based on Context
+
+```typescript
+import { VFile } from "vfile";
+
+function createProcessor(context: "page" | "section" | "subsection") {
+  const shiftMap = {
+    page: 0,
+    section: 1,
+    subsection: 2,
+  };
+
+  return remark()
+    .use(remarkShiftHeadings, { shift: shiftMap[context] });
+}
+
+// Use in different contexts
+const pageProcessor = createProcessor("page");
+const sectionProcessor = createProcessor("section");
+```
+
+### Conditional Shifting
+
+```typescript
+import { VFile } from "vfile";
+
+const processor = remark()
+  .use(() => (tree, file: VFile) => {
+    // Get shift from frontmatter
+    const shift = file.data.frontmatter?.headingShift ?? 0;
+
+    // Apply shift dynamically
+    visit(tree, "heading", (node: Heading) => {
+      node.depth = Math.max(1, Math.min(6, node.depth + shift));
+    });
+  });
+```
+
+## Important Constraints
+
+1. **Peer Dependency** - Requires unified v11+
+2. **Markdown Transform** - Operates on Markdown AST (mdast)
+3. **Level Clamping** - Always clamps to h1-h6 range
+4. **Type Safety** - Heading depth is typed as `1 | 2 | 3 | 4 | 5 | 6`
+5. **TypeScript** - Strict mode enabled
+6. **Biome Formatting** - Code must pass Biome checks
+
+## Dependencies
+
+**Runtime:**
+- `unified` - Unified text processing framework (peer dependency)
+- `unist-util-visit` - AST visitor utility
+- `vfile` - Virtual file abstraction
+
+**Dev Dependencies:**
+- `remark` - Markdown processor
+- `remark-parse` - Markdown parser
+- `vitest` - Testing framework
+
+## Limitations
+
+1. **Fixed Shift** - Shift amount must be known at processing time
+2. **No Conditional Logic** - Can't shift specific headings differently
+3. **No Context Awareness** - Doesn't analyze document structure
+4. **Simple Algorithm** - Just adds/subtracts from depth
+
+## Future Enhancements
+
+- Support heading-specific rules
+- Add option to preserve h1 (never shift first h1)
+- Support heading ID preservation
+- Add option to maintain relative structure only
+- Support custom depth ranges
+
+## Related Packages
+
+- **rehype-footnotes** - Sister rehype plugin
+- **remark-lazy-links** - Sister remark plugin
+- Often used with content management systems
+
+## Real-World Example
+
+### Astro Component
+
+```astro
+---
+import { remark } from "remark";
+import remarkShiftHeadings from "remark-shift-headings";
+import remarkRehype from "remark-rehype";
+import rehypeStringify from "rehype-stringify";
+
+interface Props {
+  content: string;
+  level: number;
+}
+
+const { content, level } = Astro.props;
+
+const html = await remark()
+  .use(remarkShiftHeadings, { shift: level })
+  .use(remarkRehype)
+  .use(rehypeStringify)
+  .process(content);
+---
+
+<div set:html={html} />
+```
+
+Usage:
+
+```astro
+<Layout>
+  <h1>Main Page Title</h1>
+
+  <!-- Markdown starts with h1, but renders as h2+ -->
+  <MarkdownContent content={articleMd} level={1} />
+</Layout>
+```

--- a/packages/repopo-docs/CLAUDE.md
+++ b/packages/repopo-docs/CLAUDE.md
@@ -1,0 +1,345 @@
+# CLAUDE.md - repopo-docs
+
+Package-specific guidance for the Repopo documentation site.
+
+## Package Overview
+
+Documentation website for the Repopo repository policy enforcement tool, built with Astro and Starlight. The site provides user guides, CLI reference documentation, API documentation, and policy authoring guides.
+
+**Framework:** Astro with Starlight theme
+**Deployment:** Netlify
+
+## Essential Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Start development server
+pnpm dev
+# or
+pnpm start
+
+# Build site for production
+pnpm build:site
+
+# Preview production build
+pnpm preview
+
+# Check Astro configuration
+pnpm check:astro
+
+# Clean build artifacts
+pnpm clean
+```
+
+## Development Workflow
+
+### Local Development
+
+```bash
+# Start dev server with hot reload
+pnpm dev
+
+# Site available at http://localhost:4321 (default)
+```
+
+The dev server provides:
+- Hot module replacement (HMR)
+- Instant page updates on file changes
+- Error overlay for debugging
+
+### Building for Production
+
+```bash
+# Build static site
+pnpm build:site
+
+# Output: dist/ directory
+
+# Preview production build locally
+pnpm preview
+```
+
+## Project Structure
+
+```
+packages/repopo-docs/
+├── src/
+│   ├── content/
+│   │   └── docs/          # Documentation markdown files
+│   │       ├── index.md   # Homepage
+│   │       ├── guide/     # User guides
+│   │       ├── policies/  # Built-in policies docs
+│   │       └── api/       # API reference (auto-generated)
+│   ├── assets/            # Images, fonts, etc.
+│   └── styles/            # Custom styles
+├── astro.config.mjs       # Astro configuration
+├── dist/                  # Build output (generated)
+├── package.json
+└── tsconfig.json
+```
+
+## Content Structure
+
+### Documentation Sections
+
+**Guide:**
+- Getting started
+- Installation
+- Configuration
+- Creating custom policies
+- CLI usage
+- Best practices
+
+**Policies:**
+- Built-in policy reference
+- Policy configuration examples
+- Policy patterns
+
+**API Reference:**
+- Auto-generated from repopo source
+- TypeScript API documentation
+- Type definitions
+
+## Astro Configuration
+
+Key features enabled in `astro.config.mjs`:
+
+**Starlight Theme:**
+- Documentation-focused theme
+- Built-in search
+- Responsive navigation
+- Dark mode support
+
+**Plugins:**
+- `starlight-heading-badges` - Badges for headings
+- `starlight-links-validator` - Validate internal links
+- `starlight-package-managers` - Package manager tabs
+- `starlight-typedoc` - TypeDoc API documentation
+
+**Netlify Adapter:**
+- Server-side rendering (SSR) support
+- Edge functions
+- Automatic deployment
+
+## Content Management
+
+### Writing Documentation
+
+Documentation files use Markdown with frontmatter:
+
+```markdown
+---
+title: Page Title
+description: Page description for SEO
+---
+
+# Page Title
+
+Content goes here...
+```
+
+**Starlight Features:**
+- Automatic table of contents
+- Syntax highlighting for code blocks
+- Callouts (note, tip, warning, danger)
+- Tabs for content variants
+
+### API Reference
+
+API documentation is **auto-generated** from the repopo package using TypeDoc:
+
+**Configuration:**
+- TypeDoc configuration in astro.config.mjs or typedoc.json
+- Starlight-TypeDoc plugin integration
+- Markdown output format
+
+**Regeneration:**
+API docs are regenerated on each build automatically.
+
+### Policy Documentation
+
+Built-in policies should be documented with:
+- Policy name and description
+- Configuration options
+- Examples
+- Use cases
+- Related policies
+
+**Example:**
+
+```markdown
+## NoJsFileExtensions
+
+Prevents ambiguous `.js` file extensions in the repository.
+
+### Configuration
+
+\`\`\`typescript
+makePolicy(NoJsFileExtensions, undefined, {
+  excludeFiles: [".*/bin/.*js"]  // Exclude bin scripts
+})
+\`\`\`
+
+### Why?
+
+Using `.js` extension with `"type": "module"` in package.json...
+```
+
+## TypeDoc Integration
+
+API documentation is generated from the repopo source code:
+
+**Included:**
+- Public API exports
+- Type definitions
+- Class documentation
+- Interface documentation
+
+**Configuration:**
+- Entry point: repopo/src/index.ts
+- Output: src/content/docs/api/
+- Format: Markdown (Starlight-compatible)
+
+## Styling and Theming
+
+### Custom Styles
+
+Add custom CSS in `src/styles/`:
+
+```css
+/* Custom theme overrides */
+:root {
+  --sl-color-accent: #your-color;
+}
+```
+
+### Fonts
+
+Custom fonts loaded via `@fontsource`:
+- `@fontsource/ibm-plex-serif`
+- `@fontsource/metropolis`
+- `@fontsource/open-sans`
+
+## Deployment
+
+### Netlify Deployment
+
+**Configuration:**
+- Output: `dist/` directory
+- Build command: `pnpm build:site`
+- Adapter: `@astrojs/netlify`
+
+**Automatic Deployment:**
+- Deploys on push to main branch
+- Preview builds for pull requests
+- Edge functions support
+
+### Build Validation
+
+Before deploying:
+
+```bash
+# Check Astro configuration
+pnpm check:astro
+
+# Build site
+pnpm build:site
+
+# Verify build output
+pnpm preview
+```
+
+## Plugin Configuration
+
+### Starlight Package Managers
+
+Enables package manager tabs for installation commands:
+
+```markdown
+```bash npm2yarn
+npm install repopo
+\```
+```
+
+Automatically generates tabs for npm, yarn, pnpm.
+
+### Starlight Links Validator
+
+Validates internal links during build:
+- Detects broken links
+- Warns about missing pages
+- Validates anchors
+
+### Starlight TypeDoc
+
+Generates API documentation:
+- Extracts types from TypeScript source
+- Creates markdown pages
+- Integrates with Starlight navigation
+
+## Important Constraints
+
+1. **Part of Monorepo** - Uses `workspace:^` for repopo dependency
+2. **Auto-Generated Content** - API docs regenerated on build
+3. **Astro Framework** - Follow Astro conventions
+4. **Starlight Theme** - Use Starlight-compatible markdown features
+5. **Static Site** - All content must be statically generated
+6. **Netlify Deployment** - Site deployed via Netlify adapter
+
+## Dependencies
+
+**Key Dependencies:**
+- `astro` - Framework
+- `@astrojs/starlight` - Documentation theme
+- `@astrojs/netlify` - Netlify adapter
+- `repopo` - Source for API reference (workspace dependency)
+- `typedoc` - API documentation generation
+
+**Starlight Plugins:**
+- `starlight-heading-badges`
+- `starlight-links-validator`
+- `starlight-package-managers`
+- `starlight-typedoc`
+
+## Common Tasks
+
+### Adding a New Page
+
+1. Create `src/content/docs/new-page.md`
+2. Add frontmatter with title and description
+3. Write content in Markdown
+4. Update navigation if needed (in astro.config.mjs)
+5. Test locally: `pnpm dev`
+6. Build: `pnpm build:site`
+
+### Updating API Reference
+
+API reference is automatically regenerated on each build from the repopo source code. No manual updates needed.
+
+### Adding Policy Documentation
+
+1. Create `src/content/docs/policies/policy-name.md`
+2. Document policy purpose, configuration, and examples
+3. Link from main policies index page
+4. Test locally and build
+
+### Troubleshooting Build Issues
+
+```bash
+# Clear Astro cache
+pnpm clean
+
+# Check for configuration errors
+pnpm check:astro
+
+# Rebuild from scratch
+pnpm clean && pnpm build:site
+```
+
+## Related Packages
+
+- **repopo** - Source for API docs and CLI reference
+- **dill-docs** - Similar documentation site structure
+- **ccl-docs** - Similar documentation site structure

--- a/packages/sort-tsconfig/CLAUDE.md
+++ b/packages/sort-tsconfig/CLAUDE.md
@@ -1,0 +1,367 @@
+# CLAUDE.md - sort-tsconfig
+
+Package-specific guidance for the TypeScript config sorting tool.
+
+## Package Overview
+
+Command-line tool and library to sort tsconfig.json files. Provides both a CLI (`sort-tsconfig`) and a Repopo policy for automatic enforcement. Keeps TypeScript configuration files clean and consistent.
+
+**Binary:** `sort-tsconfig`
+**Dev Mode:** `./bin/dev.js`
+**Prod Mode:** `./bin/run.js`
+**Repopo Integration:** Exports `SortTsconfigsPolicy` for repository policy enforcement
+
+## Essential Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the package
+pnpm build
+
+# Run tests
+pnpm test
+
+# Run tests with coverage
+pnpm test:coverage
+
+# Format code
+pnpm format
+
+# Lint code
+pnpm lint
+pnpm lint:fix  # Auto-fix issues
+
+# Check formatting
+pnpm check
+
+# Generate OCLIF manifest
+pnpm build:manifest
+
+# Update README from command help
+pnpm build:readme
+
+# Update command snapshots
+./bin/dev.js snapshot:generate
+./bin/dev.js snapshot:compare
+
+# Clean build artifacts
+pnpm clean
+```
+
+## Using sort-tsconfig CLI
+
+```bash
+# Development mode (no compilation needed)
+./bin/dev.js [path]
+
+# Sort specific file
+./bin/dev.js ./tsconfig.json
+
+# Sort all tsconfig files in directory
+./bin/dev.js .
+
+# Dry run (check without modifying)
+./bin/dev.js --check
+
+# Production mode
+sort-tsconfig [path]
+
+# Show help
+sort-tsconfig --help
+```
+
+## Command Structure
+
+Uses a **single-command strategy** in OCLIF - the main command is directly accessible:
+
+```
+src/
+├── commands/
+│   └── sort-tsconfig.ts   # Main sort command
+├── lib/
+│   ├── sort.ts            # Sorting implementation
+│   ├── policy.ts          # Repopo policy
+│   └── utils.ts           # Utilities
+└── index.ts              # Public API exports
+```
+
+**Exportable Command:**
+The sort command is exported at `sort-tsconfig/command` for reuse in other CLI tools.
+
+## Key Features
+
+### Sorting Algorithm
+
+Sorts tsconfig.json properties in a logical order:
+
+1. **Metadata** - `$schema`, `extends`
+2. **Compiler Options** - All options in `compilerOptions`
+3. **File Inclusion** - `include`, `exclude`, `files`
+4. **References** - `references` array
+5. **Watch Options** - `watchOptions`
+6. **Type Acquisition** - `typeAcquisition`
+
+**Preserves:**
+- Comments (JSONC format)
+- Indentation style
+- Nested structure
+
+### JSONC Support
+
+Handles TypeScript's JSON with Comments format:
+
+```jsonc
+{
+  // This comment is preserved
+  "compilerOptions": {
+    "strict": true  // So is this one
+  }
+}
+```
+
+Uses `tiny-jsonc` for parsing and `sort-jsonc` for sorting.
+
+### Glob Pattern Matching
+
+```bash
+# Sort all tsconfig files in project
+sort-tsconfig .
+
+# Finds:
+# - tsconfig.json
+# - tsconfig.*.json
+# - */tsconfig.json
+# - */tsconfig.*.json
+```
+
+Uses `tinyglobby` for efficient file discovery.
+
+## Repopo Policy Integration
+
+### Exporting Policy
+
+```typescript
+// sort-tsconfig exports a Repopo policy
+export { SortTsconfigsPolicy } from "sort-tsconfig";
+```
+
+### Using in repopo.config.ts
+
+```typescript
+import { makePolicy, type RepopoConfig } from "repopo";
+import { SortTsconfigsPolicy } from "sort-tsconfig";
+
+const config: RepopoConfig = {
+  policies: [
+    makePolicy(SortTsconfigsPolicy),
+  ],
+};
+
+export default config;
+```
+
+**Policy Behavior:**
+- Matches all `**/tsconfig*.json` files
+- Checks if files are sorted
+- Auto-fixes by sorting when `--fix` flag is used
+- Reports violations in CI
+
+### Policy Configuration
+
+```typescript
+makePolicy(SortTsconfigsPolicy, undefined, {
+  excludeFiles: ["**/node_modules/**"]  // Exclude specific paths
+})
+```
+
+## Project Structure
+
+```
+packages/sort-tsconfig/
+├── src/
+│   ├── commands/
+│   │   └── sort-tsconfig.ts  # CLI command
+│   ├── lib/
+│   │   ├── sort.ts           # Core sorting logic
+│   │   └── policy.ts         # Repopo policy
+│   └── index.ts              # Public exports
+├── esm/                      # Compiled output
+├── test/                     # Tests
+├── bin/                      # Binary entry points
+├── oclif.manifest.json       # Auto-generated
+└── package.json
+```
+
+## API Usage
+
+### As a Library
+
+```typescript
+import { sortTsconfig } from "sort-tsconfig";
+
+// Sort tsconfig content
+const sorted = sortTsconfig(content);
+
+// Or sort file
+import { readFileSync, writeFileSync } from "node:fs";
+
+const content = readFileSync("tsconfig.json", "utf-8");
+const sorted = sortTsconfig(content);
+writeFileSync("tsconfig.json", sorted);
+```
+
+### Detecting Sort Status
+
+```typescript
+import { isTsconfigSorted } from "sort-tsconfig";
+
+const content = readFileSync("tsconfig.json", "utf-8");
+
+if (!isTsconfigSorted(content)) {
+  console.log("tsconfig.json needs sorting");
+}
+```
+
+## Testing Strategy
+
+### Unit Tests (Vitest)
+
+```bash
+# Run tests
+pnpm test
+
+# Watch mode
+pnpm test -- --watch
+
+# Coverage
+pnpm test:coverage
+```
+
+**Test Coverage:**
+- Sorting algorithm correctness
+- JSONC comment preservation
+- Indentation preservation
+- Edge cases (empty files, malformed JSON)
+- Glob pattern matching
+
+### Command Snapshot Tests
+
+```bash
+# Generate snapshots
+./bin/dev.js snapshot:generate --filepath test/commands/_snapshots/commands.json
+
+# Verify snapshots
+./bin/dev.js snapshot:compare --filepath test/commands/_snapshots/commands.json
+```
+
+Uses `@oclif/plugin-command-snapshot` to validate command structure.
+
+## Common Workflows
+
+### Adding to Existing Project
+
+1. Install: `pnpm add -D sort-tsconfig`
+2. Sort files: `npx sort-tsconfig .`
+3. Add to package.json scripts:
+   ```json
+   {
+     "scripts": {
+       "sort:tsconfig": "sort-tsconfig ."
+     }
+   }
+   ```
+4. Optional: Add Repopo policy for enforcement
+
+### Pre-Commit Hook
+
+```bash
+# Using lint-staged
+# .lintstagedrc.json
+{
+  "**/tsconfig*.json": ["sort-tsconfig"]
+}
+```
+
+### CI Validation
+
+```bash
+# Check if files are sorted (fails if not)
+sort-tsconfig --check .
+```
+
+### Integration with Repopo
+
+```bash
+# In monorepo with repopo
+./packages/repopo/bin/dev.js check --fix
+
+# Automatically sorts all tsconfig files
+```
+
+## Sort Order Reference
+
+### Top-Level Properties
+
+1. `$schema`
+2. `extends`
+3. `compilerOptions`
+4. `include`
+5. `exclude`
+6. `files`
+7. `references`
+8. `watchOptions`
+9. `typeAcquisition`
+
+### Compiler Options
+
+Sorted alphabetically within categories:
+- Paths and modules
+- Language and environment
+- Type checking
+- Emit
+- Advanced
+
+## Important Constraints
+
+1. **Part of Monorepo** - Uses `workspace:^` protocol
+2. **Single Command** - No subcommands
+3. **JSONC Format** - Must preserve comments
+4. **OCLIF Structure** - Follow OCLIF conventions
+5. **Repopo Integration** - Exports policy for enforcement
+6. **TypeScript** - Strict mode enabled
+7. **Biome Formatting** - Code must pass Biome checks
+
+## Dependencies
+
+**Key Runtime Dependencies:**
+- `@oclif/core` - CLI framework
+- `@tylerbu/cli-api` - Base command classes
+- `@tylerbu/fundamentals` - Shared utilities
+- `tiny-jsonc` - JSONC parser
+- `sort-jsonc` - JSONC sorter
+- `tinyglobby` - File globbing
+- `detect-indent` - Indentation detection
+
+**Peer Dependencies:**
+- `repopo` (optional) - For policy integration
+
+**Key Dev Dependencies:**
+- `vitest` - Testing framework
+- `memfs` - In-memory filesystem for tests
+- `@oclif/plugin-command-snapshot` - Snapshot testing
+
+## Related Packages
+
+- **repopo** - Policy enforcement (consumer)
+- **@tylerbu/cli-api** - Base command infrastructure
+- **@tylerbu/fundamentals** - Shared utilities
+
+## Future Enhancements
+
+- Support custom sort orders
+- Add configuration file support
+- Support other JSON config files (package.json sorting already handled by sort-package-json)
+- Add watch mode
+- Support automatic fixing in editor integrations

--- a/packages/xkcd2-api/CLAUDE.md
+++ b/packages/xkcd2-api/CLAUDE.md
@@ -1,0 +1,343 @@
+# CLAUDE.md - @tylerbu/xkcd2-api
+
+Package-specific guidance for the xkcd2.com API library.
+
+## Package Overview
+
+TypeScript APIs and types used in implementations of xkcd2.com. This library provides type definitions, interfaces, and utilities for working with XKCD comic data and related functionality.
+
+**Purpose:** Shared types and APIs for xkcd2.com projects
+**Target Site:** xkcd2.com (personal XKCD-related project)
+
+## Essential Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Build the package
+pnpm build
+
+# Run tests
+pnpm test
+
+# Run tests with coverage
+pnpm test:coverage
+
+# Format code
+pnpm format
+
+# Lint code
+pnpm lint
+pnpm lint:fix  # Auto-fix issues
+
+# Check formatting
+pnpm check
+
+# Generate API documentation
+pnpm build:api
+
+# Generate TypeDoc documentation
+pnpm build:docs
+
+# Clean build artifacts
+pnpm clean
+```
+
+## Project Structure
+
+```
+packages/xkcd2-api/
+├── src/
+│   ├── index.ts           # Main exports
+│   ├── types.ts           # Type definitions
+│   ├── comic.ts           # Comic-related APIs
+│   └── utils.ts           # Utility functions
+├── esm/                   # Compiled output
+├── test/                  # Vitest tests
+├── _temp/                 # Generated documentation
+├── package.json
+└── tsconfig.json
+```
+
+## Key Exports
+
+### Comic Types
+
+```typescript
+import type { Comic, ComicMetadata, ComicInfo } from "@tylerbu/xkcd2-api";
+
+interface Comic {
+  num: number;           // Comic number
+  title: string;         // Comic title
+  img: string;           // Image URL
+  alt: string;           // Alt text
+  transcript?: string;   // Transcript (if available)
+  link?: string;         // Link (if available)
+  news?: string;         // News (if available)
+  safe_title: string;    // URL-safe title
+  year: string;          // Publication year
+  month: string;         // Publication month
+  day: string;           // Publication day
+}
+```
+
+### API Functions
+
+```typescript
+import { getComic, getLatestComic, searchComics } from "@tylerbu/xkcd2-api";
+
+// Get specific comic by number
+const comic = await getComic(123);
+
+// Get latest comic
+const latest = await getLatestComic();
+
+// Search comics
+const results = await searchComics("science");
+```
+
+## XKCD API
+
+### Official XKCD API
+
+The official XKCD API provides JSON data:
+
+```
+# Latest comic
+https://xkcd.com/info.0.json
+
+# Specific comic
+https://xkcd.com/614/info.0.json
+```
+
+**Response Format:**
+```json
+{
+  "num": 614,
+  "title": "Woodpecker",
+  "safe_title": "Woodpecker",
+  "img": "https://imgs.xkcd.com/comics/woodpecker.png",
+  "alt": "If you don't have an extension cord...",
+  "year": "2009",
+  "month": "7",
+  "day": "24",
+  "transcript": "...",
+  "link": "",
+  "news": ""
+}
+```
+
+### Wrapper Functions
+
+This library provides typed wrappers around the XKCD API:
+
+```typescript
+// Type-safe comic fetching
+const comic: Comic = await getComic(614);
+
+// Type-safe latest comic
+const latest: Comic = await getLatestComic();
+
+// Validate comic data
+const isValid = validateComic(data);
+```
+
+## Common Use Cases
+
+### Fetching Comics
+
+```typescript
+import { getComic } from "@tylerbu/xkcd2-api";
+
+// Get a specific comic
+try {
+  const comic = await getComic(1);
+  console.log(comic.title);
+  console.log(comic.img);
+  console.log(comic.alt);
+} catch (error) {
+  console.error("Failed to fetch comic", error);
+}
+```
+
+### Working with Metadata
+
+```typescript
+import { ComicMetadata, parseComicDate } from "@tylerbu/xkcd2-api";
+
+const metadata: ComicMetadata = {
+  num: 614,
+  title: "Woodpecker",
+  publishDate: parseComicDate("2009", "7", "24"),
+};
+```
+
+### Caching
+
+```typescript
+import { ComicCache } from "@tylerbu/xkcd2-api";
+
+const cache = new ComicCache();
+
+// Fetch with caching
+const comic = await cache.get(614);
+
+// Check if cached
+if (cache.has(614)) {
+  const cached = cache.get(614);
+}
+```
+
+## Development Workflow
+
+### Adding New Types
+
+1. Add type definition in `src/types.ts`
+2. Export from `src/index.ts`
+3. Write tests in `test/types.test.ts`
+4. Run `pnpm build:api` to generate docs
+5. Update documentation
+
+### Adding New Functions
+
+1. Implement function in appropriate module
+2. Add JSDoc comments
+3. Export from `src/index.ts`
+4. Write unit tests
+5. Run tests: `pnpm test`
+6. Generate docs: `pnpm build:docs`
+
+## Testing Strategy
+
+Uses Vitest for unit testing:
+
+```bash
+# Run tests
+pnpm test
+
+# Watch mode
+pnpm test -- --watch
+
+# Coverage
+pnpm test:coverage
+```
+
+**Test Coverage:**
+- Type validation
+- API wrapper functions
+- Utility functions
+- Edge cases
+
+**Example Test:**
+```typescript
+import { test, expect } from "vitest";
+import { validateComic } from "../src/index.js";
+
+test("validates comic data", () => {
+  const validComic = {
+    num: 1,
+    title: "Test",
+    img: "https://example.com/image.png",
+    alt: "Alt text",
+    safe_title: "Test",
+    year: "2023",
+    month: "1",
+    day: "1",
+  };
+
+  expect(validateComic(validComic)).toBe(true);
+});
+```
+
+## API Documentation
+
+### Generation
+
+The package uses **API Extractor** and **TypeDoc**:
+
+```bash
+# Generate API Extractor documentation
+pnpm build:api
+
+# Generate TypeDoc documentation
+pnpm build:docs
+```
+
+**Outputs:**
+- API Extractor: `_temp/api-extractor/`
+- TypeDoc: `_temp/docs/` (markdown format)
+
+### Documentation Comments
+
+Use JSDoc format for all public APIs:
+
+```typescript
+/**
+ * Fetches a specific XKCD comic by number.
+ *
+ * @param num - The comic number to fetch
+ * @returns A promise that resolves to the comic data
+ * @throws {Error} If the comic doesn't exist or fetch fails
+ *
+ * @example
+ * ```typescript
+ * const comic = await getComic(614);
+ * console.log(comic.title);
+ * ```
+ */
+export async function getComic(num: number): Promise<Comic> {
+  // Implementation
+}
+```
+
+## Important Constraints
+
+1. **Part of Monorepo** - Standard monorepo package
+2. **Zero Runtime Dependencies** - Keep dependencies minimal
+3. **TypeScript** - Strict mode enabled
+4. **Type Safety** - All APIs fully typed
+5. **API Wrapper** - Wraps official XKCD API
+6. **Biome Formatting** - Code must pass Biome checks
+
+## Dependencies
+
+**Dev Dependencies:**
+- `@biomejs/biome` - Formatting and linting
+- `@microsoft/api-extractor` - API documentation
+- `typedoc` - TypeScript documentation
+- `vitest` - Testing framework
+- `typescript` - TypeScript compiler
+
+**No Runtime Dependencies** - Keeps bundle size minimal
+
+## Integration
+
+This package is used by:
+- xkcd2.com website
+- Related xkcd2 projects
+- Personal tools for XKCD comic analysis
+
+## Future Enhancements
+
+- Add comic search functionality
+- Implement local caching layer
+- Add comic recommendation engine
+- Support bulk comic fetching
+- Add transcript parsing utilities
+- Implement comic metadata enrichment
+
+## XKCD Resources
+
+**Official:**
+- XKCD Website: https://xkcd.com
+- XKCD API: https://xkcd.com/json.html
+- XKCD Archive: https://xkcd.com/archive/
+
+**Community:**
+- Explain XKCD: https://www.explainxkcd.com/
+- XKCD on GitHub: Various community projects
+
+## Related Packages
+
+This is a standalone API package with no direct dependencies on other monorepo packages. It follows the same development practices and tooling as other packages in the monorepo.


### PR DESCRIPTION
Add package-specific CLAUDE.md documentation files for:
- cli-api: Base classes and API helpers for OCLIF CLI projects
- dill-cli: File download and extraction CLI tool
- dill-docs: Dill documentation site (Astro/Starlight)
- fundamentals: Zero-dependency utility library
- levee-client: Fluid Framework service client
- lilconfig-loader-ts: TypeScript loader for lilconfig
- rehype-footnotes: Rehype plugin for Littlefoot.js footnotes
- remark-lazy-links: Remark plugin for lazy link numbering
- remark-shift-headings: Remark plugin to shift heading levels
- repopo-docs: Repopo documentation site (Astro/Starlight)
- sort-tsconfig: TypeScript config sorting tool and Repopo policy
- xkcd2-api: Types and APIs for xkcd2.com projects

Each CLAUDE.md provides:
- Package overview and key features
- Essential commands and development workflow
- Architecture and usage patterns
- Testing strategy
- Integration with other packages
- Important constraints