### PR TITLE
fix(sail-infrastructure): resolve flaky test due to git index.lock race

### DIFF
--- a/packages/sail-infrastructure/src/test/versions.test.ts
+++ b/packages/sail-infrastructure/src/test/versions.test.ts
@@ -3,7 +3,7 @@ import * as path from "pathe";
 
 import * as semver from "semver";
 import { simpleGit } from "simple-git";
-import { afterEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { loadBuildProject } from "../buildProject.js";
 import type { ReleaseGroupName, WorkspaceName } from "../types.js";
@@ -30,7 +30,10 @@ assert(secondWorkspace !== undefined);
 const git = simpleGit(testRepoRoot);
 
 describe("setVersion", () => {
-	afterEach(async () => {
+	// Use beforeEach instead of afterEach for cleanup to avoid git index.lock race conditions.
+	// With afterEach, the cleanup from test N can still be running when test N+1's afterEach starts,
+	// causing concurrent git operations that conflict on .git/index.lock.
+	beforeEach(async () => {
 		await git.checkout(["HEAD", "--", testRepoRoot]);
 		repo.reload();
 	});


### PR DESCRIPTION
## Summary

- Fix flaky `test:coverage` task in `@tylerbu/sail-infrastructure` caused by git index.lock race conditions
- Change `afterEach` to `beforeEach` for git cleanup in `versions.test.ts`

## Problem

The `versions.test.ts` file used `afterEach` to reset the git state via `git.checkout()`. When tests ran with coverage enabled, timing differences caused the `afterEach` cleanup from one test to still be running when the next test's `afterEach` started, resulting in concurrent git operations that conflicted on `.git/index.lock`:

```
Error: fatal: Unable to create '/Volumes/Code/tools-monorepo/.git/index.lock': File exists.
Another git process seems to be running in this repository...
```

## Solution

Use `beforeEach` instead of `afterEach` for cleanup. This ensures the git reset completes before each test begins, avoiding the race condition where multiple `afterEach` hooks compete for the git index lock.

## Test plan

- [x] Run `pnpm nx run @tylerbu/sail-infrastructure:test:coverage` multiple times to verify stability
- [x] All 176 tests pass consistently