### PR TITLE
docs(ccl-docs): remove phase/stage terminology from implementation guides

### DIFF
--- a/packages/ccl-docs/src/content/docs/ai-quickstart.md
+++ b/packages/ccl-docs/src/content/docs/ai-quickstart.md
@@ -229,37 +229,43 @@ function getCompatibleTests(
 }
 ```
 
-## Function-Based Progressive Implementation
+## CCL Functions
 
-Implement CCL functions in this order:
+### Core Functions (Required)
 
-### Stage 1: Core Parsing (Required)
-**163 tests for `parse`**
+**`parse`** - Convert text to flat key-value entries
 - Split lines on first `=`
 - Trim keys, preserve value whitespace
 - Handle multiline via indentation
 
-**77 tests for `build_hierarchy`**
+**`build_hierarchy`** - Build nested objects via recursive parsing
 - Implement internal `parse_indented` helper (not public API) that strips common leading whitespace from multiline values
 - Recursively parse entry values using this helper
 - Fixed-point algorithm: stop when values contain no `=`
 - Create nested objects from flat entries
 
-### Stage 2: Typed Access (Optional - 84 tests total)
-- `get_string` - 7 tests (28 assertions)
-- `get_int` - 11 tests (47 assertions)
-- `get_bool` - 12 tests (49 assertions)
-- `get_float` - 6 tests (28 assertions)
-- `get_list` - 48 tests (186 assertions)
+### Typed Access Functions (Optional)
 
-### Stage 3: Processing (Optional - 38 tests total)
-- `filter` - 3 tests - Remove comment entries
-- `compose` - 9 tests - Monoid composition
-- `canonical_format` - 14 tests - Standardized output
-- `round_trip` - 12 tests - Format → parse identity
+Extract values with type conversion:
+- `get_string` - String extraction
+- `get_int` - Integer parsing
+- `get_bool` - Boolean parsing
+- `get_float` - Float parsing
+- `get_list` - List extraction
 
-### Experimental (NOT Standard Progression)
-- Dotted keys - 10 tests - **Explicitly experimental**
+### Processing Functions (Optional)
+
+- `filter` - Remove comment entries
+- `compose` - Monoid composition of entry lists
+
+### Formatting Functions (Optional)
+
+- `canonical_format` - Standardized output
+- `round_trip` - Format → parse identity
+
+### Experimental Functions
+
+- `expand_dotted` - Dotted key expansion (`foo.bar` → nested) - **Explicitly experimental**
 
 ## Common AI Assistant Pitfalls
 

--- a/packages/ccl-docs/src/content/docs/parsing-algorithm.md
+++ b/packages/ccl-docs/src/content/docs/parsing-algorithm.md
@@ -26,7 +26,7 @@ nested =
   sibling = another nested
 ```
 
-### Stage 1: Parse Entries
+### Parse Entries
 
 Split lines on first `=` character:
 
@@ -44,7 +44,7 @@ Split lines on first `=` character:
 - Empty key `= value` → list item
 - Comment entry `/ = text` → key is `/`, value is `text`
 
-### Stage 2: Build Hierarchy
+### Build Hierarchy
 
 Group entries by indentation level:
 
@@ -64,7 +64,7 @@ Entry {key: "parent", value: "child = nested\nsibling = another"}
 - Lines with MORE indentation than previous = part of previous value
 - Lines with SAME/LESS indentation = new entry at that level
 
-### Stage 3: Recursive Parsing (Fixed Point)
+### Recursive Parsing (Fixed Point)
 
 Parse values that contain CCL syntax:
 
@@ -93,13 +93,13 @@ users =
   = bob
 ```
 
-Step 1 - Parse entries:
+**Parse entries:**
 ```
 Entry {key: "database", value: "host = localhost\nport = 5432"}
 Entry {key: "users", value: "= alice\n= bob"}
 ```
 
-Step 2 - Recursive parsing:
+**Recursive parsing:**
 ```
 database.value contains '=' → parse recursively:
   Entry {key: "host", value: "localhost"}
@@ -110,7 +110,7 @@ users.value contains '=' → parse recursively:
   Entry {key: "", value: "bob"}
 ```
 
-Step 3 - Build objects:
+**Build objects:**
 ```json
 {
   "database": {
@@ -129,9 +129,9 @@ Pseudocode for recursive parser:
 
 ```python
 def parse_ccl(text):
-    entries = parse_entries(text)  # Stage 1: split on '='
-    hierarchy = build_hierarchy(entries)  # Stage 2: group by indentation
-    return recursively_parse(hierarchy)  # Stage 3: fixed point
+    entries = parse_entries(text)  # split on '='
+    hierarchy = build_hierarchy(entries)  # group by indentation
+    return recursively_parse(hierarchy)  # fixed point
 
 def recursively_parse(entries):
     result = {}

--- a/packages/ccl-docs/src/content/docs/test-suite-guide.md
+++ b/packages/ccl-docs/src/content/docs/test-suite-guide.md
@@ -25,7 +25,8 @@ Each test includes:
 - **Core**: `parse`, `build_hierarchy`
 - **Typed Access**: `get_string`, `get_int`, `get_bool`, `get_float`, `get_list`
 - **Processing**: `filter`, `compose`, `expand_dotted`
-- **Formatting**: `canonical_format`
+- **Formatting**: `print`, `canonical_format`, `round_trip`
+- **Algebraic Properties**: `compose_associative`, `identity_left`, `identity_right`
 
 **Features** - Optional language features:
 - `comments`, `experimental_dotted_keys`, `empty_keys`, `multiline`, `unicode`, `whitespace`
@@ -35,36 +36,46 @@ Each test includes:
 - `boolean_strict` vs `boolean_lenient`
 - `list_coercion_enabled` vs `list_coercion_disabled`
 
-## Progressive Implementation
+## Filtering Tests by Function
 
-### Phase 1: Core Parsing
-**Validation**: `parse`
+### Core Parsing
 
-Filter tests:
+**`parse`** - Filter tests:
 ```javascript
 tests.filter(t => t.validation === 'parse')
 ```
 
-### Phase 2: Object Construction
-**Validation**: `build_hierarchy`
-
-Filter tests:
+**`build_hierarchy`** - Filter tests:
 ```javascript
 tests.filter(t => t.validation === 'build_hierarchy')
 ```
 
-### Phase 3: Typed Access
-**Validation**: `get_string`, `get_int`, `get_bool`, `get_float`, `get_list`
+### Typed Access
 
-Filter tests:
+**`get_string`, `get_int`, `get_bool`, `get_float`, `get_list`** - Filter tests:
 ```javascript
 tests.filter(t => t.validation.startsWith('get_'))
 ```
 
-### Phase 4: Optional Features
-**Features**: `comments`, `experimental_dotted_keys`
+### Formatting
 
-Filter by supported features:
+**`print`, `round_trip`** - Filter tests:
+```javascript
+tests.filter(t => t.validation === 'print' || t.validation === 'round_trip')
+```
+
+The `print` function verifies structure-preserving output. For inputs in standard format (single space around `=`, 2-space indentation), `print(parse(x)) == x`.
+
+### Algebraic Properties
+
+**`compose_associative`, `identity_left`, `identity_right`** - These tests use multiple inputs to verify monoid properties:
+```javascript
+tests.filter(t => ['compose_associative', 'identity_left', 'identity_right'].includes(t.validation))
+```
+
+### Optional Features
+
+Filter by supported features (`comments`, `experimental_dotted_keys`, etc.):
 ```javascript
 tests.filter(t => t.features.every(f => supportedFeatures.includes(f)))
 ```


### PR DESCRIPTION
## Summary

- Replace numbered phases and stages with function-focused organization
- Docs now emphasize CCL functions and their capabilities rather than implying a sequential implementation order

## Changes

- **ai-quickstart.md**: Replace "Stage 1/2/3" with function category sections (Core Functions, Typed Access Functions, Processing Functions, etc.)
- **test-suite-guide.md**: Replace "Phase 1-6" with "Filtering Tests by Function" organized by function category
- **parsing-algorithm.md**: Remove "Stage" prefixes from algorithm sections, use descriptive headers instead

## Test plan

- [ ] Verify docs build successfully
- [ ] Review rendered pages for clarity