### PR TITLE
ci: control Nx Cloud via repository variables

### DIFF
--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -8,15 +8,26 @@ inputs:
     type: boolean
     default: false
   enable-nx-cloud:
-    description: Enable Nx Cloud (if false, sets NX_NO_CLOUD=true)
+    description: |
+      Enable Nx Cloud. Options:
+        - 'true': Enable Nx Cloud
+        - 'false': Disable Nx Cloud (sets NX_NO_CLOUD=true)
+        - 'auto' (default): Use repository variable ENABLE_NX_CLOUD to decide
     required: false
-    type: boolean
-    default: false
+    type: string
+    default: 'auto'
   nx-cloud-token:
     description: Nx Cloud access token (only used if enable-nx-cloud is true)
     required: false
     type: string
     default: ''
+  enable-nx-cloud-var:
+    description: |
+      Value of a repository variable to control Nx Cloud (e.g., vars.NX_CLOUD_PR or vars.NX_CLOUD_MAIN).
+      Only used when enable-nx-cloud is 'auto'. Set to 'true' to enable, any other value disables.
+    required: false
+    type: string
+    default: 'false'
 
 runs:
   using: composite
@@ -28,10 +39,20 @@ runs:
         # Set custom cache directory to avoid conflicts with coverage outputs
         echo "NX_CACHE_DIRECTORY=/tmp/nx-cache" >> $GITHUB_ENV
 
-        # Configure Nx Cloud
-        if [ "${{ inputs.enable-nx-cloud }}" = "true" ]; then
+        # Determine if Nx Cloud should be enabled
+        # Priority: explicit input > repository variable > default (disabled)
+        ENABLE_NX_CLOUD="${{ inputs.enable-nx-cloud }}"
+        if [ "$ENABLE_NX_CLOUD" = "auto" ]; then
+          # Use repository variable value (defaults to 'false' if not set)
+          ENABLE_NX_CLOUD="${{ inputs.enable-nx-cloud-var }}"
+        fi
+
+        # Configure Nx Cloud based on resolved value
+        if [ "$ENABLE_NX_CLOUD" = "true" ]; then
+          echo "Nx Cloud: enabled"
           echo "NX_CLOUD_ACCESS_TOKEN=${{ inputs.nx-cloud-token }}" >> $GITHUB_ENV
         else
+          echo "Nx Cloud: disabled"
           echo "NX_NO_CLOUD=true" >> $GITHUB_ENV
         fi
     # Cache Nx local cache between runs

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -38,7 +38,8 @@ jobs:
       - uses: ./.github/actions/setup-nx
         with:
           enable-cache: false
-          # Nx Cloud disabled by default (enable-nx-cloud: false)
+          # Nx Cloud controlled by repository variables: NX_CLOUD_MAIN for main branch, NX_CLOUD_PR for PRs
+          enable-nx-cloud-var: ${{ github.ref == 'refs/heads/main' && vars.NX_CLOUD_MAIN || vars.NX_CLOUD_PR }}
 
       - name: Run CI checks, builds, and tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,6 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-env:
-  NX_NO_CLOUD: true # Disable Nx Cloud for release builds - ensures clean local builds
-
 jobs:
   release:
     name: Release
@@ -33,6 +30,11 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-node-pnpm
+
+      - uses: ./.github/actions/setup-nx
+        with:
+          # Nx Cloud controlled by repository variable NX_CLOUD_RELEASE
+          enable-nx-cloud-var: ${{ vars.NX_CLOUD_RELEASE }}
 
       # Despite the name, this step either creates/updates a PR or publishes packages
       # To improve the experience viewing the results in the Actions UI, subsequent steps log


### PR DESCRIPTION
## Summary

- Add support for controlling Nx Cloud enablement through GitHub Actions repository variables
- Separate variables for different workflow contexts:
  - `NX_CLOUD_PR`: Controls PR builds
  - `NX_CLOUD_MAIN`: Controls main branch builds
  - `NX_CLOUD_RELEASE`: Controls release workflow
- The `setup-nx` action now defaults to 'auto' mode that reads from repository variables
- Explicit `enable-nx-cloud: 'true'` or `'false'` can still override the variable

## How to Configure

Go to Settings → Secrets and variables → Actions → Variables and create:

| Variable | Controls |
|----------|----------|
| `NX_CLOUD_PR` | PR builds |
| `NX_CLOUD_MAIN` | Main branch builds |
| `NX_CLOUD_RELEASE` | Release workflow |

Set each to `true` to enable Nx Cloud, or `false` (or leave unset) to disable.