### PR TITLE
fix(ci): pass Nx Cloud token and add PR label opt-in

### DIFF
--- a/.github/actions/setup-nx/action.yml
+++ b/.github/actions/setup-nx/action.yml
@@ -2,11 +2,6 @@ name: Setup Nx
 description: Configure Nx cache and affected detection
 
 inputs:
-  enable-cache:
-    description: Enable Nx local cache
-    required: false
-    type: boolean
-    default: false
   enable-nx-cloud:
     description: |
       Enable Nx Cloud. Options:
@@ -55,18 +50,6 @@ runs:
           echo "Nx Cloud: disabled"
           echo "NX_NO_CLOUD=true" >> $GITHUB_ENV
         fi
-    # Cache Nx local cache between runs
-    - name: Cache Nx
-      if: inputs.enable-cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache@v4
-      with:
-        path: /tmp/nx-cache
-        key: nx-${{ runner.os }}-${{ github.ref_name }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('**/project.json', 'nx.json') }}
-        restore-keys: |
-          nx-${{ runner.os }}-${{ github.ref_name }}-${{ hashFiles('pnpm-lock.yaml') }}-
-          nx-${{ runner.os }}-${{ github.ref_name }}-
-          nx-${{ runner.os }}-main-
-          nx-${{ runner.os }}-
 
     # Sets NX_BASE and NX_HEAD for accurate affected detection
     - uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # ratchet:nrwl/nx-set-shas@v4

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -48,7 +48,6 @@ jobs:
 
       - uses: ./.github/actions/setup-nx
         with:
-          enable-cache: false
           # Nx Cloud enabled by: repository variable (NX_CLOUD_MAIN/NX_CLOUD_PR) OR 'nx-cloud' PR label
           enable-nx-cloud-var: ${{ github.ref == 'refs/heads/main' && vars.NX_CLOUD_MAIN || (vars.NX_CLOUD_PR == 'true' || steps.nx-cloud-label.outputs.enabled == 'true') }}
           nx-cloud-token: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

- Pass the `NX_CLOUD_ACCESS_TOKEN` secret to the setup-nx action (was configured but not wired up)
- Add support for opting PRs into Nx Cloud by adding the `nx-cloud` label

## Test plan

- [x] Verify CI passes on this PR (with Nx Cloud disabled by default)
- [x] Add `nx-cloud` label to test opt-in functionality