### PR TITLE
docs(ccl-docs): update behavior names and CRLF documentation

### DIFF
--- a/packages/ccl-docs/src/content/docs/ai-quickstart.md
+++ b/packages/ccl-docs/src/content/docs/ai-quickstart.md
@@ -47,10 +47,11 @@ description: Guide for AI assistants helping users implement CCL parsers and tes
 ### Behaviors (Mutually Exclusive Choices)
 
 - `boolean_strict` vs `boolean_lenient`
-- `crlf_normalize_to_lf` vs `crlf_preserve_literal`
-- `tabs_preserve` vs `tabs_to_spaces`
-- `strict_spacing` vs `loose_spacing`
+- `crlf_normalize_to_lf` vs `crlf_preserve_literal` (default: preserve)
+- `tabs_as_content` vs `tabs_as_whitespace`
+- `indent_spaces` vs `indent_tabs`
 - `list_coercion_enabled` vs `list_coercion_disabled`
+- `array_order_insertion` vs `array_order_lexicographic`
 
 ### Variants (Specification Versions)
 

--- a/packages/ccl-docs/src/content/docs/getting-started.md
+++ b/packages/ccl-docs/src/content/docs/getting-started.md
@@ -70,7 +70,7 @@ The value `mode = sandbox\ncapacity = 2` is **recursively parsed as CCL**.
 
 **Unicode**: UTF-8 supported. Keys and values can contain any Unicode characters.
 
-**CRLF vs LF**: Line endings normalized to LF (`\n`) before parsing.
+**CRLF vs LF**: CCL treats only LF (`\n`) as a newline; CR characters are preserved as content by default. Implementations may optionally normalize CRLF to LF with the `crlf_normalize_to_lf` behavior.
 
 **Whitespace-only values**: Preserved if present after `=`.
 

--- a/packages/ccl-docs/src/content/docs/index.mdx
+++ b/packages/ccl-docs/src/content/docs/index.mdx
@@ -12,6 +12,9 @@ hero:
     - text: Implement a parser
       link: /implementing-ccl/
       variant: secondary
+    - text: AI Quickstart
+      link: /ai-quickstart/
+      icon: rocket
 ---
 
 import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';


### PR DESCRIPTION
## Summary

- Update behavior names in documentation to match schema changes:
  - `tabs_preserve` → `tabs_as_content`
  - `tabs_to_spaces` → `tabs_as_whitespace`
  - Add `indent_spaces`, `indent_tabs` behaviors
- Fix incorrect CRLF handling statement in getting-started.md
  - CRs are preserved as content by default (not normalized)
  - Implementations may optionally normalize with `crlf_normalize_to_lf`
- Add AI Quickstart link to homepage hero section

## Files Changed

- `packages/ccl-docs/src/content/docs/getting-started.md` - CRLF fix
- `packages/ccl-docs/src/content/docs/ai-quickstart.md` - Behavior name updates
- `packages/ccl-docs/src/content/docs/index.mdx` - AI Quickstart homepage link

## Test plan

- [ ] Site builds successfully
- [ ] Links work correctly