### PR TITLE
docs(ccl-docs): add AI implementation guide and prompts pages

### DIFF
--- a/packages/ccl-docs/astro.config.mjs
+++ b/packages/ccl-docs/astro.config.mjs
@@ -79,7 +79,11 @@ export default defineConfig({
 			sidebar: [
 				{
 					label: "For AI Assistants",
-					items: [{ slug: "ai-quickstart" }],
+					items: [
+						{ slug: "ai-quickstart" },
+						{ slug: "ai-implementation-guide" },
+						{ slug: "ai-prompts" },
+					],
 				},
 				{
 					label: "Learning CCL",

--- a/packages/ccl-docs/src/content/docs/ai-implementation-guide.md
+++ b/packages/ccl-docs/src/content/docs/ai-implementation-guide.md
@@ -1,0 +1,430 @@
+---
+title: AI Implementation Guide
+description: Complete guide for AI agents building CCL implementations in any programming language.
+---
+
+:::note[For AI Agents]
+This page is designed for AI agents to read. If you're a human looking to give your AI agent a prompt, see [CCL Prompts](/ai-prompts).
+:::
+
+# Building a CCL Implementation
+
+This guide provides everything an AI agent needs to implement CCL (Categorical Configuration Language) in any programming language.
+
+## Quick Start
+
+**CCL** is a minimal configuration language based on key-value pairs with recursive structure. The core insight: if a value contains `=` characters, it can be parsed as nested CCL. This recursive fixed-point parsing is what creates hierarchy from flat text.
+
+**Required functions:**
+- `parse` - Convert text to flat key-value entries
+- `build_hierarchy` - Convert entries to nested structure
+
+**Everything else is optional.** Typed access, filtering, and formatting are library conveniences.
+
+## Resources
+
+| Resource | URL |
+|----------|-----|
+| Documentation | https://ccl.tylerbutler.com |
+| Test Suite | https://github.com/tylerbutler/ccl-test-data |
+| Go Implementation | https://github.com/tylerbutler/ccl-go |
+| Gleam Implementation | https://github.com/tylerbutler/ccl_gleam |
+| OCaml Implementation | https://github.com/tylerbutler/ccl-ocaml |
+
+---
+
+## Core Functions (Required)
+
+### `parse`
+
+Converts raw CCL text into a flat list of key-value entries.
+
+**Signature:**
+```
+parse(text: string) -> List[Entry]
+```
+
+**Entry type:**
+```
+Entry {
+  key: string    // Configuration key (empty string for list items)
+  value: string  // Raw value (may contain nested CCL syntax)
+}
+```
+
+**Algorithm:**
+
+1. Split input on newlines (LF only; CR is content, not a line break)
+2. For each line, find the first `=` character
+3. Everything before `=` is the key (trimmed of whitespace)
+4. Everything after `=` is the value (leading whitespace trimmed, trailing preserved)
+5. Handle indented continuation lines (part of previous entry's value)
+
+**Example:**
+```ccl
+name = Alice
+database =
+  host = localhost
+  port = 5432
+```
+
+Parses to:
+```
+[
+  Entry {key: "name", value: "Alice"},
+  Entry {key: "database", value: "\n  host = localhost\n  port = 5432"}
+]
+```
+
+**Key rules:**
+- Split on **first** `=` only: `a = b = c` → key: `a`, value: `b = c`
+- Trim whitespace from keys: `"  key  "` → `"key"`
+- Preserve value whitespace (except leading): `"  value  "` → `"value  "`
+- Empty key `= value` → list item (key is empty string)
+- Comment entry `/ = text` → key is `/`, value is `text`
+
+**Indentation handling:**
+- Count leading whitespace characters (spaces or tabs)
+- Lines with MORE indentation than previous = continuation of previous value
+- Lines with SAME or LESS indentation = new entry
+
+See [Parsing Algorithm](/parsing-algorithm) for complete details.
+
+---
+
+### `build_hierarchy`
+
+Converts flat entries into a nested object structure via recursive parsing.
+
+**Signature:**
+```
+build_hierarchy(entries: List[Entry]) -> CCL
+```
+
+**CCL type:**
+```
+CCL = Map[string, CCL | string | List[string]]
+```
+
+**Algorithm:**
+
+```pseudocode
+function build_hierarchy(entries):
+    result = {}
+    for entry in entries:
+        if entry.key == "":
+            # Empty key = list item
+            add_to_list(result, "", entry.value)
+        else if contains_ccl_syntax(entry.value):
+            # Value has '=' → parse recursively
+            nested_entries = parse(entry.value)
+            result[entry.key] = build_hierarchy(nested_entries)
+        else:
+            # Terminal value (fixed point reached)
+            result[entry.key] = entry.value
+    return result
+
+function contains_ccl_syntax(value):
+    return "=" in value
+```
+
+**Fixed-point termination:** Recursion stops when values contain no `=` characters. Plain strings like `"localhost"` or `"5432"` have no structure to parse.
+
+**Example:**
+
+Input entries:
+```
+[
+  Entry {key: "database", value: "\n  host = localhost\n  port = 5432"},
+  Entry {key: "users", value: "\n  = alice\n  = bob"}
+]
+```
+
+After recursive parsing:
+```json
+{
+  "database": {
+    "host": "localhost",
+    "port": "5432"
+  },
+  "users": ["alice", "bob"]
+}
+```
+
+**Handling special cases:**
+- **Empty keys:** Multiple entries with empty key `""` form a list
+- **Duplicate keys:** Merge values or convert to list (implementation choice)
+- **Nested values:** Any value containing `=` is parsed recursively
+
+See [Parsing Algorithm](/parsing-algorithm) for the complete algorithm with examples.
+
+---
+
+## Typed Access Functions (Optional)
+
+These provide convenient, type-safe value extraction. All are optional library features.
+
+### `get_string`
+
+```
+get_string(ccl: CCL, path: string) -> string | Error
+```
+
+Navigate to path and return string value. Error if path not found or value is not a string.
+
+### `get_int`
+
+```
+get_int(ccl: CCL, path: string) -> int | Error
+```
+
+Navigate to path, parse value as integer. Error if not a valid integer.
+
+### `get_bool`
+
+```
+get_bool(ccl: CCL, path: string) -> bool | Error
+```
+
+Navigate to path, parse value as boolean.
+
+**Behavior choice:**
+- `boolean_strict`: Only `"true"` and `"false"`
+- `boolean_lenient`: Also accepts `"yes"/"no"`, `"1"/"0"`
+
+### `get_float`
+
+```
+get_float(ccl: CCL, path: string) -> float | Error
+```
+
+Navigate to path, parse value as floating-point number.
+
+### `get_list`
+
+```
+get_list(ccl: CCL, path: string) -> List[string] | Error
+```
+
+Navigate to path, return list of values.
+
+**Behavior choice:**
+- `list_coercion_enabled`: Single value returns `[value]`
+- `list_coercion_disabled`: Error if not actually a list
+
+**Path navigation:** Use dot notation for nested access: `database.host`
+
+See [Library Features](/library-features) for implementation details.
+
+---
+
+## Processing Functions (Optional)
+
+### `filter`
+
+```
+filter(entries: List[Entry], predicate: fn(Entry) -> bool) -> List[Entry]
+```
+
+Filter entries based on predicate. Common use: remove comments (entries where key starts with `/`).
+
+### `compose`
+
+```
+compose(entries1: List[Entry], entries2: List[Entry]) -> List[Entry]
+```
+
+Concatenate entry lists. This is a monoid operation - entries form a monoid under composition with empty list as identity.
+
+See [Library Features](/library-features) for details on entry processing.
+
+---
+
+## Formatting Functions (Optional)
+
+### `print`
+
+```
+print(entries: List[Entry]) -> string
+```
+
+Convert entries back to CCL text. **Structure-preserving:** For inputs in standard format, `print(parse(x)) == x`.
+
+### `canonical_format`
+
+```
+canonical_format(ccl: CCL) -> string
+```
+
+Convert CCL object to standardized text format. **Semantic-preserving:** Normalizes formatting but preserves meaning.
+
+**Key difference:**
+- `print` preserves original structure (comments, ordering, formatting)
+- `canonical_format` produces normalized output from the parsed model
+
+See [Library Features: Formatting](/library-features#formatting-functions) for details.
+
+---
+
+## Implementation Behaviors
+
+CCL implementations make choices about edge cases. Declare your choices and the test suite will filter appropriately.
+
+| Behavior Group | Options | Description |
+|----------------|---------|-------------|
+| Line Endings | `crlf_preserve_literal` / `crlf_normalize_to_lf` | Keep `\r` chars or normalize to LF |
+| Boolean Parsing | `boolean_strict` / `boolean_lenient` | Only true/false or also yes/no |
+| Tab Handling | `tabs_as_content` / `tabs_as_whitespace` | Preserve tabs or treat as whitespace |
+| Indentation | `indent_spaces` / `indent_tabs` | Output formatting style |
+| List Coercion | `list_coercion_enabled` / `list_coercion_disabled` | Single value as one-item list |
+| Array Ordering | `array_order_insertion` / `array_order_lexicographic` | Preserve order or sort |
+
+See [Behavior Reference](/behavior-reference) for detailed documentation of each behavior.
+
+---
+
+## Testing Your Implementation
+
+### Test Suite
+
+The official test suite at https://github.com/tylerbutler/ccl-test-data provides comprehensive validation:
+
+- **447 assertions** across **205 tests**
+- **JSON format** in `generated_tests/` directory
+- **Capability-based filtering** by function, feature, and behavior
+
+### Test Format
+
+Each test specifies:
+```json
+{
+  "name": "basic_key_value_pairs_parse",
+  "validation": "parse",
+  "input": "name = Alice\nage = 42",
+  "expected": {
+    "count": 2,
+    "entries": [
+      {"key": "name", "value": "Alice"},
+      {"key": "age", "value": "42"}
+    ]
+  },
+  "functions": ["parse"],
+  "features": [],
+  "behaviors": []
+}
+```
+
+### Filtering Tests
+
+Filter by your implementation's capabilities:
+
+```javascript
+const runnable = tests.filter(test =>
+  // Only run tests for functions you've implemented
+  test.functions.every(fn => implementedFunctions.includes(fn)) &&
+  // Skip tests with conflicting behaviors
+  !test.conflicts?.behaviors?.some(b => myBehaviors.includes(b))
+);
+```
+
+### Check for Existing Test Runners
+
+Before building a test runner, check if one exists for your language:
+- **Go:** Built-in test runner in ccl-test-data repository
+- **Other languages:** You may need to build a test loader
+
+See [Test Suite Guide](/test-suite-guide) for complete filtering examples and test format documentation.
+
+---
+
+## Common Pitfalls
+
+:::caution[Critical Implementation Notes]
+These are the most common mistakes when implementing CCL:
+:::
+
+1. **Use snake_case everywhere**
+   - Correct: `build_hierarchy`, `get_string`, `experimental_dotted_keys`
+   - Wrong: `build-hierarchy`, `getString`, `dotted-keys`
+
+2. **Split on FIRST `=` only**
+   - Input: `key = value = more`
+   - Key: `key`, Value: `value = more`
+
+3. **CCL is NOT like YAML/JSON**
+   - No special syntax for nesting (just indentation + `=`)
+   - Recursive fixed-point parsing, not grammar-based
+   - Values containing `=` are recursively parsed
+
+4. **Only LF is a newline**
+   - CR (`\r`) is preserved as content
+   - CRLF handling is a behavior choice
+
+5. **Trim keys, preserve value whitespace**
+   - Key: trim both sides
+   - Value: trim leading only, preserve trailing
+
+6. **Empty key = list item**
+   - `= alice` has key `""` and value `"alice"`
+   - Multiple empty-key entries form a list
+
+See [AI Quickstart](/ai-quickstart#common-ai-assistant-pitfalls) for additional guidance.
+
+---
+
+## Data Types Summary
+
+### Entry
+
+The fundamental unit from parsing:
+
+```
+Entry {
+  key: string    // Configuration key (empty string for list items)
+  value: string  // Raw value (may contain nested CCL syntax)
+}
+```
+
+### CCL Object
+
+The hierarchical structure after `build_hierarchy`:
+
+```
+CCL = Map[string, CCL | string | List]
+```
+
+Where values can be:
+- **String** - Terminal value (no `=` in content)
+- **CCL** - Nested object (parsed from value containing `=`)
+- **List** - Array of values (from multiple empty-key entries)
+
+---
+
+## Recommended Implementation Order
+
+Start with core functions and add features incrementally:
+
+1. **`parse`** - Basic key-value parsing
+2. **`build_hierarchy`** - Recursive object construction
+3. **`get_string`** - Simple path navigation
+4. **`get_int`, `get_bool`, `get_float`** - Type conversions
+5. **`get_list`** - List extraction
+6. **`filter`, `compose`** - Entry processing
+7. **`print`, `canonical_format`** - Output formatting
+
+The test suite supports this progression - filter tests by `functions` array to run only relevant tests at each stage.
+
+---
+
+## Quick Reference
+
+```
+REQUIRED:        parse, build_hierarchy
+TYPED ACCESS:    get_string, get_int, get_bool, get_float, get_list
+PROCESSING:      filter, compose
+FORMATTING:      print, canonical_format
+TERMINOLOGY:     Always use snake_case
+ALGORITHM:       Recursive fixed-point parsing
+TEST SUITE:      github.com/tylerbutler/ccl-test-data
+DOCUMENTATION:   ccl.tylerbutler.com
+```

--- a/packages/ccl-docs/src/content/docs/ai-prompts.md
+++ b/packages/ccl-docs/src/content/docs/ai-prompts.md
@@ -1,0 +1,221 @@
+---
+title: CCL Prompts for AI Agents
+description: Ready-to-use prompts for AI agents building CCL implementations.
+---
+
+:::note[For Humans]
+This page is for you to copy prompts and give them to your AI agent. The AI should read the [AI Implementation Guide](/ai-implementation-guide) instead.
+:::
+
+# CCL Prompts for AI Agents
+
+Copy-paste these prompts to guide AI agents building CCL implementations.
+
+## How to Use
+
+1. **Choose a prompt** that matches your goal
+2. **Replace `[language]`** with your target language (Rust, Python, etc.)
+3. **Paste into your AI agent** (Claude, ChatGPT, Copilot, etc.)
+4. **The AI will read the docs** and follow the specification
+
+---
+
+## Full Implementation
+
+### Basic Implementation
+
+```
+Build a CCL parser in [language].
+
+Read https://ccl.tylerbutler.com/ai-implementation-guide/ for the complete
+specification. Start with parse and build_hierarchy, then add typed access.
+
+Use tests from https://github.com/tylerbutler/ccl-test-data to validate.
+```
+
+### With Specific Behaviors
+
+```
+Build a CCL parser in [language] with these behaviors:
+- crlf_normalize_to_lf (normalize line endings)
+- boolean_strict (only "true" and "false")
+- list_coercion_disabled (require explicit list syntax)
+
+Read https://ccl.tylerbutler.com/ai-implementation-guide/ for the specification.
+See https://ccl.tylerbutler.com/behavior-reference/ for behavior details.
+```
+
+### Minimal Core Only
+
+```
+Build a minimal CCL parser in [language] with only the required functions:
+- parse (text to entries)
+- build_hierarchy (entries to nested object)
+
+Skip typed access and formatting for now.
+
+Read https://ccl.tylerbutler.com/ai-implementation-guide/#core-functions-required
+```
+
+---
+
+## Feature-Specific
+
+### Add Typed Access
+
+```
+I have a CCL parser with parse and build_hierarchy working.
+
+Add typed access functions:
+- get_string
+- get_int
+- get_bool
+- get_float
+- get_list
+
+Follow https://ccl.tylerbutler.com/ai-implementation-guide/#typed-access-functions-optional
+Use https://ccl.tylerbutler.com/library-features/ for implementation details.
+```
+
+### Add Single Function
+
+```
+Add the get_list function to my CCL implementation following the spec at
+https://ccl.tylerbutler.com/ai-implementation-guide/#get_list
+
+Use list_coercion_disabled behavior (error if value is not actually a list).
+```
+
+### Add Formatting
+
+```
+Add formatting functions to my CCL implementation:
+- print (structure-preserving round-trip)
+- canonical_format (normalized output)
+
+Follow https://ccl.tylerbutler.com/library-features/#formatting-functions
+```
+
+### Add Entry Processing
+
+```
+Add entry processing functions to my CCL implementation:
+- filter (remove entries by predicate, e.g., comments)
+- compose (concatenate entry lists)
+
+Follow https://ccl.tylerbutler.com/library-features/
+```
+
+---
+
+## Test Integration
+
+### Set Up Test Suite
+
+```
+Set up test integration for my CCL implementation using the test suite at
+https://github.com/tylerbutler/ccl-test-data
+
+The tests are in generated_tests/*.json format. Filter tests to only run
+those for functions I've implemented: parse, build_hierarchy.
+
+See https://ccl.tylerbutler.com/test-suite-guide/ for test format details.
+```
+
+### Build Test Runner
+
+```
+Build a test runner for my [language] CCL implementation that:
+1. Loads JSON tests from https://github.com/tylerbutler/ccl-test-data/generated_tests/
+2. Filters by my implemented functions: [list your functions]
+3. Runs each test and reports pass/fail
+4. Handles the "expected" format with "count" fields
+
+See https://ccl.tylerbutler.com/test-suite-guide/ for the test format.
+```
+
+### Run Specific Test Categories
+
+```
+Run only the parse function tests from the CCL test suite.
+
+Filter tests where validation === "parse" from the generated_tests/ directory.
+Report which tests pass and fail.
+```
+
+---
+
+## Debugging & Maintenance
+
+### Fix Failing Tests
+
+```
+My CCL parser is failing these tests: [paste test names or errors]
+
+Review my implementation against the algorithm at
+https://ccl.tylerbutler.com/parsing-algorithm/ and identify issues.
+
+Common pitfalls are listed at
+https://ccl.tylerbutler.com/ai-implementation-guide/#common-pitfalls
+```
+
+### Review Implementation
+
+```
+Review my CCL implementation for correctness.
+
+Check against:
+- Algorithm: https://ccl.tylerbutler.com/parsing-algorithm/
+- Common pitfalls: https://ccl.tylerbutler.com/ai-implementation-guide/#common-pitfalls
+- Behaviors: https://ccl.tylerbutler.com/behavior-reference/
+
+Identify any deviations from the specification.
+```
+
+### Add Missing Error Handling
+
+```
+Review my CCL implementation's error handling.
+
+The spec at https://ccl.tylerbutler.com/ai-implementation-guide/ describes
+expected error cases. Ensure my implementation handles:
+- Missing keys (path not found)
+- Type mismatches (e.g., get_int on non-integer)
+- Malformed input (lines without =)
+```
+
+---
+
+## Quick Prompts
+
+### One-Liner: Start Fresh
+
+```
+Implement CCL in [language] following https://ccl.tylerbutler.com/ai-implementation-guide/
+```
+
+### One-Liner: Quick Reference
+
+```
+Read https://ccl.tylerbutler.com/ai-quickstart/ for CCL terminology and concepts.
+```
+
+### One-Liner: Check My Work
+
+```
+Compare my CCL parser to the spec at https://ccl.tylerbutler.com/parsing-algorithm/
+```
+
+---
+
+## Prompt Tips
+
+**Be specific about functions:** Instead of "add more features," say "add get_string and get_int."
+
+**Specify behaviors:** If you care about boolean parsing or list coercion, say so explicitly.
+
+**Reference specific URLs:** Point to exact sections like `#get_list` for focused work.
+
+**Include your constraints:** Language version, dependencies, style preferences.
+
+**Mention the test suite:** Always reference https://github.com/tylerbutler/ccl-test-data for validation.

--- a/packages/ccl-docs/src/content/docs/ai-quickstart.md
+++ b/packages/ccl-docs/src/content/docs/ai-quickstart.md
@@ -3,6 +3,10 @@ title: AI Assistant Quickstart
 description: Quick reference for AI assistants helping users implement CCL parsers and test runners
 ---
 
+:::note[For AI Agents]
+This page is a quick reference for AI agents. For a complete implementation guide, see [AI Implementation Guide](/ai-implementation-guide). Humans looking for prompts should see [CCL Prompts](/ai-prompts).
+:::
+
 # CCL Quick Reference for AI Assistants
 
 > Single-page orientation for AI assistants. For details, follow links to specific documentation pages.


### PR DESCRIPTION
## Summary

Adds comprehensive AI-focused documentation to the CCL docs site:

- **ai-implementation-guide.md** (430 lines): Complete specification for AI agents building CCL implementations, covering all functions (`parse`, `build_hierarchy`, typed access, processing, formatting), algorithms, behaviors, and testing guidance
- **ai-prompts.md** (221 lines): Ready-to-use prompts that humans can copy-paste to instruct AI agents for various CCL tasks (full implementation, feature-specific, test integration, debugging)
- Updates **ai-quickstart.md** with audience callout distinguishing it from the new pages
- Adds sidebar navigation entries for the new pages under "For AI Assistants"

The pages include audience notes (AI-targeted vs human-targeted) to help users understand which documentation to use.