### PR TITLE
ci: add build provenance attestation for npm packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: write       # For changesets PR creation
+      pull-requests: write  # For changesets PR updates
+      id-token: write       # OIDC token for npm trusted publishing
+      attestations: write   # For GitHub build attestations
 
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
@@ -103,6 +107,19 @@ jobs:
         uses: parkerbxyz/json-to-markdown-table@564b4821b8128f1cd7a0eb6b5616680a818719ab # ratchet:parkerbxyz/json-to-markdown-table@v1
         with:
           json: '${{ steps.publish.outputs.report }}'
+
+      # Generate GitHub-native attestations for published packages (public npm only)
+      # This creates SLSA-compliant build provenance verifiable via `gh attestation verify`
+      - name: Generate build attestations
+        if: |
+          steps.publish.outputs.report != null &&
+          steps.publish.outputs.report != '[]' &&
+          github.event.inputs.publish_public != 'false'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            packages/*/esm/**/*.js
+            packages/*/esm/**/*.mjs
 
       - name: No packages published
         if: steps.publish.outputs.report == '[]'

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"ci:docs": "nx run-many -t build:docs",
 		"ci:lint": "biome ci --reporter=github",
 		"ci:local": "nx affected -t ci --base=HEAD~1",
-		"ci:publish": "pnpm publish -r --access public --report-summary --no-git-checks",
+		"ci:publish": "pnpm publish -r --access public --provenance --report-summary --no-git-checks",
 		"ci:publish:internal": "pnpm publish -r --report-summary --no-git-checks --filter \"@tylerbu/*\"",
 		"ci:test": "nx run-many -t test:coverage",
 		"ci:version": "pnpm run release:license && changeset version && pnpm install --no-frozen-lockfile && pnpm format && pnpm build",


### PR DESCRIPTION
## Summary

Add cryptographically signed build provenance for all published npm packages using npm's `--provenance` flag and GitHub's `actions/attest-build-provenance` action.

## Changes

- **`package.json`**: Add `--provenance` flag to `ci:publish` command to enable npm-native provenance generation
- **`release.yml`**: Replace overly-broad `write-all` permissions with scoped permissions:
  - `contents: write` - changesets PR creation
  - `pull-requests: write` - changesets PR updates  
  - `id-token: write` - OIDC token for npm trusted publishing
  - `attestations: write` - GitHub build attestations
- **`release.yml`**: Add `actions/attest-build-provenance@v2` step to generate SLSA-compliant attestations for published packages (public npm only)

## Notes

- Provenance works immediately with existing `NPM_TOKEN` authentication
- Full OIDC trusted publishing (eliminating `NPM_TOKEN`) requires manual configuration on npmjs.com for each package
- Attestations are verifiable via `gh attestation verify`