### PR TITLE
fix(cli-api): make consola peer dependency truly optional

### DIFF
--- a/.changeset/fix-consola-optional-peer-dep.md
+++ b/.changeset/fix-consola-optional-peer-dep.md
@@ -1,0 +1,7 @@
+---
+"@tylerbu/cli-api": patch
+---
+
+Make consola peer dependency truly optional by removing its exports from the main entrypoint.
+
+The consola logger functions are now only available via the dedicated `@tylerbu/cli-api/loggers/consola` entrypoint. This allows consumers who don't use the consola logger to avoid installing the consola peer dependency.

--- a/packages/cli-api/api-docs/cli-api.api.md
+++ b/packages/cli-api/api-docs/cli-api.api.md
@@ -87,18 +87,7 @@ export type CommitMergeability = "clean" | "conflict" | "maybeClean";
 export const ConfigFileFlag: OptionFlag<string | undefined, CustomOptions>;
 
 // @public
-export interface ConsolaLoggerOptions {
-    colors?: boolean;
-}
-
-// @public
 export function createBasicLogger(): Logger;
-
-// @public
-export function createConsolaLogger(style?: PrefixStyle, options?: ConsolaLoggerOptions): Logger;
-
-// @public
-export function createExtendedConsolaLogger(style: PrefixStyle, options?: ConsolaLoggerOptions): ExtendedLogger;
 
 // @beta
 export interface DependencyChange {

--- a/packages/cli-api/src/index.ts
+++ b/packages/cli-api/src/index.ts
@@ -58,11 +58,6 @@ export type {
 	LoggingFunction,
 } from "./logger.js";
 export { createBasicLogger } from "./loggers/basic.js";
-export {
-	type ConsolaLoggerOptions,
-	createConsolaLogger,
-	createExtendedConsolaLogger,
-} from "./loggers/consola.js";
 export type { PrefixStyle } from "./loggers/prefixReporter.js";
 export {
 	detectAllPackageManagers,

--- a/packages/cli-api/src/logger.ts
+++ b/packages/cli-api/src/logger.ts
@@ -30,7 +30,7 @@ export type LoggingFunction = (message?: string, ...args: unknown[]) => void;
  *
  * Built-in implementations:
  * - {@link createBasicLogger} - Simple console output with colored prefixes (default)
- * - {@link createConsolaLogger} - Rich formatting with icons via consola library (alpha)
+ * - `createConsolaLogger` (from `@tylerbu/cli-api/loggers/consola`) - Rich formatting with icons via consola library (alpha)
  *
  * To create a custom logger, implement this interface:
  *
@@ -97,7 +97,7 @@ export interface Logger {
  *
  * @example
  * ```typescript
- * import { createExtendedConsolaLogger } from "@tylerbu/cli-api";
+ * import { createExtendedConsolaLogger } from "@tylerbu/cli-api/loggers/consola";
  *
  * const logger = createExtendedConsolaLogger("capsule");
  * logger.fatal("Critical failure - shutting down");

--- a/packages/cli-api/src/loggers/consola.ts
+++ b/packages/cli-api/src/loggers/consola.ts
@@ -91,7 +91,7 @@ function formatError(message: Error | string | undefined): string {
  *
  * @example
  * ```typescript
- * import { createConsolaLogger } from "@tylerbu/cli-api";
+ * import { createConsolaLogger } from "@tylerbu/cli-api/loggers/consola";
  *
  * // Default consola formatting (icons)
  * const logger = createConsolaLogger();
@@ -151,7 +151,7 @@ export function createConsolaLogger(
  *
  * @example
  * ```typescript
- * import { createExtendedConsolaLogger } from "@tylerbu/cli-api";
+ * import { createExtendedConsolaLogger } from "@tylerbu/cli-api/loggers/consola";
  *
  * const logger = createExtendedConsolaLogger("capsule");
  * logger.fatal("Critical failure!");  // [FATAL] Critical failure!

--- a/packages/cli-api/src/loggers/prefixReporter.ts
+++ b/packages/cli-api/src/loggers/prefixReporter.ts
@@ -149,7 +149,7 @@ function formatMessage(logObj: LogObject): string {
  * @example
  * ```typescript
  * import { createConsola } from "consola";
- * import { createPrefixReporter } from "@tylerbu/cli-api";
+ * import { createPrefixReporter } from "@tylerbu/cli-api/loggers/prefixReporter";
  *
  * const consola = createConsola({
  *   reporters: [createPrefixReporter({ style: "capsule" })],

--- a/packages/repopo/src/baseCommand.ts
+++ b/packages/repopo/src/baseCommand.ts
@@ -1,9 +1,9 @@
 import {
 	CommandWithConfig,
 	type CommandWithContext,
-	createConsolaLogger,
 	type RequiresGit,
 } from "@tylerbu/cli-api";
+import { createConsolaLogger } from "@tylerbu/cli-api/loggers/consola";
 import { findGitRootSync } from "@tylerbu/fundamentals/git";
 import { type SimpleGit, simpleGit } from "simple-git";
 import { DefaultPolicyConfig, type RepopoConfig } from "./config.js";


### PR DESCRIPTION
## Summary

- Remove consola logger exports from the main `@tylerbu/cli-api` entrypoint
- Update `repopo` to import from the dedicated `@tylerbu/cli-api/loggers/consola` entrypoint
- Update documentation examples to use the correct import paths

This makes the `consola` peer dependency truly optional - consumers who don't use the consola logger can now import from `@tylerbu/cli-api` without needing to install consola.

Fixes #577
