### PR TITLE
fix(vitest): exclude non-code files from coverage analysis

### DIFF
--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -17,6 +17,16 @@ const config = defineConfig({
 		},
 		coverage: {
 			include: ["src/**"],
+			exclude: [
+				// Non-code files - V8 coverage provider fails to parse them
+				"**/*.json",
+				"**/*.md",
+				"**/*.yaml",
+				"**/*.yml",
+				// Test fixtures are test data, not source code
+				"**/fixtures/**",
+				"**/test/data/**",
+			],
 			provider: "v8",
 			// Include cobertura for better codecov integration
 			reporter: ["text", "json", "html", "cobertura"],


### PR DESCRIPTION
## Summary
- Fix V8 coverage provider parse errors in CI by excluding non-code files from coverage analysis
- Add exclusions for JSON, markdown, YAML files, and test fixture/data directories
