### PR TITLE
chore(deps): update dependencies and tooling

### DIFF
--- a/config/package.json
+++ b/config/package.json
@@ -1,25 +1,25 @@
 {
-  "name": "@tylerbu/local-config",
-  "private": true,
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "config"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    "./biome/formatter": "./biome/formatter.jsonc",
-    "./biome/linter": "./biome/linter.jsonc",
-    "./biome/oclif": "./biome/oclif.jsonc",
-    "./biome/test-files": "./biome/test-files.jsonc"
-  },
-  "devDependencies": {
-    "vitest": "^4.0.18"
-  },
-  "peerDependencies": {
-    "@biomejs/biome": "2.3.8"
-  }
+	"name": "@tylerbu/local-config",
+	"private": true,
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "config"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		"./biome/formatter": "./biome/formatter.jsonc",
+		"./biome/linter": "./biome/linter.jsonc",
+		"./biome/oclif": "./biome/oclif.jsonc",
+		"./biome/test-files": "./biome/test-files.jsonc"
+	},
+	"devDependencies": {
+		"vitest": "^4.0.18"
+	},
+	"peerDependencies": {
+		"@biomejs/biome": "2.3.8"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,258 +1,258 @@
 {
-  "name": "tools-monorepo",
-  "version": "0.0.0",
-  "private": true,
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "scripts": {
-    "build": "nx run-many -t build",
-    "build:affected": "nx affected -t build",
-    "check": "nx run tools-monorepo:check",
-    "check:all": "nx run tools-monorepo:check:all",
-    "check:deps": "syncpack lint",
-    "check:format": "biome check --linter-enabled=false --no-errors-on-unmatched",
-    "check:policy": "repopo check",
-    "check:references": "workspaces-to-typescript-project-references --check",
-    "check:types:native": "tsgo --build tsconfig.tsgo.json",
-    "ci": "nx run-many -t ci",
-    "ci:affected": "nx affected -t ci",
-    "ci:all": "nx run-many -t ci",
-    "ci:build": "nx run-many -t build build:generate",
-    "ci:check": "pnpm check",
-    "ci:check:astro": "nx run-many -t check:astro",
-    "ci:check:svelte": "nx run-many -t check:svelte",
-    "ci:docs": "nx run-many -t build:docs",
-    "ci:lint": "biome ci --reporter=github",
-    "ci:local": "nx affected -t ci --base=HEAD~1",
-    "ci:publish": "pnpm publish -r --access public --report-summary --no-git-checks",
-    "ci:publish:internal": "pnpm publish -r --report-summary --no-git-checks --filter \"@tylerbu/*\"",
-    "ci:test": "nx run-many -t test:coverage",
-    "ci:version": "pnpm run release:license && changeset version && pnpm install --no-frozen-lockfile && pnpm format && pnpm build",
-    "clean": "nx run tools-monorepo:clean:root && nx run-many -t clean",
-    "clean:root": "rimraf *.tsbuildinfo *.done.build.log",
-    "compile": "nx run-many -t build:compile",
-    "compile:native": "tsgo --build tsconfig.tsgo.json",
-    "compile:native:clean": "tsgo --build tsconfig.tsgo.json --clean && tsgo --build tsconfig.tsgo.json",
-    "deps:sync": "tbu deps sync",
-    "docs": "nx run-many -t build:docs",
-    "fix:policy": "repopo check --fix",
-    "fix:references": "workspaces-to-typescript-project-references",
-    "format": "biome check . --linter-enabled=false --write",
-    "generate:packlist": "flub generate packlist -g client --no-private",
-    "lint": "biome lint --no-errors-on-unmatched",
-    "lint:fix": "biome lint --write",
-    "release:license": "nx run-many -t release:license",
-    "sort-package-json": "sort-package-json package.json \"config/package.json\" \"packages/*/package.json\"",
-    "sort:tsconfig": "sort-tsconfig \"config/tsconfig*.json\" --write && sort-tsconfig \"packages/*/tsconfig*.json\" --write",
-    "syncpack:fix": "syncpack fix",
-    "test": "nx run-many -t test",
-    "test:coverage": "nx run-many -t test:coverage",
-    "test:tsgo-build": "tsx scripts/test-tsgo-build.mts",
-    "test:tsgo-build:full": "tsx scripts/test-tsgo-build.mts --build"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@changesets/cli": "^2.29.8",
-    "@changesets/config": "^3.1.2",
-    "@monorepo-utils/workspaces-to-typescript-project-references": "^2.11.0",
-    "@nx/js": "^22.5.0",
-    "@nx/vite": "^22.5.0",
-    "@tsconfig/node18": "^18.2.6",
-    "@tsconfig/strictest": "^2.0.8",
-    "@tylerbu/cli": "workspace:^",
-    "@tylerbu/local-config": "workspace:^",
-    "@typescript/native-preview": "7.0.0-dev.20260122.4",
-    "changesets-changelog-clean": "^1.3.0",
-    "concurrently": "^9.2.1",
-    "generate-license-file": "^4.1.1",
-    "nx": "22.5.0",
-    "pathe": "^2.0.3",
-    "repopo": "workspace:^",
-    "rimraf": "^6.1.2",
-    "semver": "^7.7.3",
-    "sort-package-json": "*",
-    "sort-tsconfig": "workspace:^",
-    "syncpack": "14.0.0-alpha.37",
-    "ts-node": "^10.9.2",
-    "tslib": "^2.8.1",
-    "tsx": "^4.21.0",
-    "type-fest": "^5.4.1"
-  },
-  "packageManager": "pnpm@10.24.0",
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowAny": [
-        "@aws-sdk/*"
-      ],
-      "ignoreMissing": [
-        "@aws-sdk/*",
-        "@octokit/core"
-      ]
-    },
-    "onlyBuiltDependencies": [
-      "@biomejs/biome",
-      "@parcel/watcher",
-      "@tailwindcss/oxide",
-      "better-sqlite3",
-      "core-js",
-      "core-js-pure",
-      "dtrace-provider",
-      "esbuild",
-      "msw",
-      "nx",
-      "protobufjs",
-      "re2",
-      "sharp",
-      "unrs-resolver",
-      "yarn"
-    ],
-    "updateConfig": {
-      "ignoreDependencies": [
-        "@types/node"
-      ]
-    },
-    "overrides": {
-      "oclif>@aws-sdk/client-cloudfront": "npm:empty-npm-package@1.0.0",
-      "oclif>@aws-sdk/client-s3": "npm:empty-npm-package@1.0.0"
-    }
-  },
-  "nx": {
-    "includedScripts": [
-      "deps:sync"
-    ],
-    "targets": {
-      "check": {
-        "dependsOn": [
-          "check:all",
-          "^check"
-        ],
-        "cache": true
-      },
-      "check:all": {
-        "dependsOn": [
-          "check:deps",
-          "check:format",
-          "check:policy",
-          "check:references",
-          "lint"
-        ],
-        "cache": true
-      },
-      "check:format": {
-        "executor": "nx:run-script",
-        "options": {
-          "script": "check:format"
-        },
-        "inputs": [
-          "{workspaceRoot}/**/*.{ts,tsx,js,jsx,mjs,cjs,mts,cts,json,jsonc,md}",
-          "!{workspaceRoot}/**/node_modules/**",
-          "!{workspaceRoot}/**/dist/**",
-          "!{workspaceRoot}/**/esm/**",
-          "{workspaceRoot}/biome.jsonc",
-          "{workspaceRoot}/config/biome/*.jsonc"
-        ],
-        "cache": true
-      },
-      "lint": {
-        "executor": "nx:run-script",
-        "options": {
-          "script": "lint"
-        },
-        "inputs": [
-          "{workspaceRoot}/**/*.{ts,tsx,js,jsx,mjs,cjs,mts,cts}",
-          "!{workspaceRoot}/**/node_modules/**",
-          "!{workspaceRoot}/**/dist/**",
-          "!{workspaceRoot}/**/esm/**",
-          "{workspaceRoot}/biome.jsonc",
-          "{workspaceRoot}/config/biome/*.jsonc"
-        ],
-        "cache": true
-      },
-      "check:deps": {
-        "executor": "nx:run-script",
-        "options": {
-          "script": "check:deps"
-        },
-        "inputs": [
-          "{workspaceRoot}/package.json",
-          "{workspaceRoot}/packages/*/package.json",
-          "{workspaceRoot}/syncpack.config.cjs",
-          "{workspaceRoot}/pnpm-lock.yaml"
-        ],
-        "cache": true
-      },
-      "check:policy": {
-        "executor": "nx:run-script",
-        "dependsOn": [
-          "sort-tsconfig:build:compile"
-        ],
-        "options": {
-          "script": "check:policy"
-        },
-        "inputs": [
-          "{workspaceRoot}/**/*",
-          "!{workspaceRoot}/**/node_modules/**",
-          "!{workspaceRoot}/**/dist/**",
-          "!{workspaceRoot}/**/esm/**",
-          "{workspaceRoot}/repopo.config.ts"
-        ],
-        "cache": true
-      },
-      "check:references": {
-        "executor": "nx:run-script",
-        "options": {
-          "script": "check:references"
-        },
-        "inputs": [
-          "{workspaceRoot}/package.json",
-          "{workspaceRoot}/packages/*/package.json",
-          "{workspaceRoot}/packages/*/tsconfig*.json",
-          "{workspaceRoot}/config/tsconfig*.json"
-        ],
-        "cache": true
-      },
-      "check:types:native": {
-        "executor": "nx:run-script",
-        "options": {
-          "script": "check:types:native"
-        },
-        "inputs": [
-          "{workspaceRoot}/**/*.{ts,tsx,mts,cts}",
-          "!{workspaceRoot}/**/node_modules/**",
-          "!{workspaceRoot}/**/dist/**",
-          "!{workspaceRoot}/**/esm/**",
-          "{workspaceRoot}/config/tsconfig*.json",
-          "{workspaceRoot}/packages/*/tsconfig*.json"
-        ],
-        "cache": true
-      },
-      "clean:root": {
-        "executor": "nx:run-script",
-        "options": {
-          "script": "clean:root"
-        },
-        "cache": false
-      },
-      "deps:sync": {
-        "dependsOn": [
-          "cli:build:compile"
-        ],
-        "inputs": [
-          "{workspaceRoot}/package.json",
-          "{workspaceRoot}/packages/*/package.json",
-          "{workspaceRoot}/pnpm-lockfile.yaml"
-        ],
-        "cache": true
-      }
-    }
-  }
+	"name": "tools-monorepo",
+	"version": "0.0.0",
+	"private": true,
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"scripts": {
+		"build": "nx run-many -t build",
+		"build:affected": "nx affected -t build",
+		"check": "nx run tools-monorepo:check",
+		"check:all": "nx run tools-monorepo:check:all",
+		"check:deps": "syncpack lint",
+		"check:format": "biome check --linter-enabled=false --no-errors-on-unmatched",
+		"check:policy": "repopo check",
+		"check:references": "workspaces-to-typescript-project-references --check",
+		"check:types:native": "tsgo --build tsconfig.tsgo.json",
+		"ci": "nx run-many -t ci",
+		"ci:affected": "nx affected -t ci",
+		"ci:all": "nx run-many -t ci",
+		"ci:build": "nx run-many -t build build:generate",
+		"ci:check": "pnpm check",
+		"ci:check:astro": "nx run-many -t check:astro",
+		"ci:check:svelte": "nx run-many -t check:svelte",
+		"ci:docs": "nx run-many -t build:docs",
+		"ci:lint": "biome ci --reporter=github",
+		"ci:local": "nx affected -t ci --base=HEAD~1",
+		"ci:publish": "pnpm publish -r --access public --report-summary --no-git-checks",
+		"ci:publish:internal": "pnpm publish -r --report-summary --no-git-checks --filter \"@tylerbu/*\"",
+		"ci:test": "nx run-many -t test:coverage",
+		"ci:version": "pnpm run release:license && changeset version && pnpm install --no-frozen-lockfile && pnpm format && pnpm build",
+		"clean": "nx run tools-monorepo:clean:root && nx run-many -t clean",
+		"clean:root": "rimraf *.tsbuildinfo *.done.build.log",
+		"compile": "nx run-many -t build:compile",
+		"compile:native": "tsgo --build tsconfig.tsgo.json",
+		"compile:native:clean": "tsgo --build tsconfig.tsgo.json --clean && tsgo --build tsconfig.tsgo.json",
+		"deps:sync": "tbu deps sync",
+		"docs": "nx run-many -t build:docs",
+		"fix:policy": "repopo check --fix",
+		"fix:references": "workspaces-to-typescript-project-references",
+		"format": "biome check . --linter-enabled=false --write",
+		"generate:packlist": "flub generate packlist -g client --no-private",
+		"lint": "biome lint --no-errors-on-unmatched",
+		"lint:fix": "biome lint --write",
+		"release:license": "nx run-many -t release:license",
+		"sort-package-json": "sort-package-json package.json \"config/package.json\" \"packages/*/package.json\"",
+		"sort:tsconfig": "sort-tsconfig \"config/tsconfig*.json\" --write && sort-tsconfig \"packages/*/tsconfig*.json\" --write",
+		"syncpack:fix": "syncpack fix",
+		"test": "nx run-many -t test",
+		"test:coverage": "nx run-many -t test:coverage",
+		"test:tsgo-build": "tsx scripts/test-tsgo-build.mts",
+		"test:tsgo-build:full": "tsx scripts/test-tsgo-build.mts --build"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@changesets/cli": "^2.29.8",
+		"@changesets/config": "^3.1.2",
+		"@monorepo-utils/workspaces-to-typescript-project-references": "^2.11.0",
+		"@nx/js": "^22.5.0",
+		"@nx/vite": "^22.5.0",
+		"@tsconfig/node18": "^18.2.6",
+		"@tsconfig/strictest": "^2.0.8",
+		"@tylerbu/cli": "workspace:^",
+		"@tylerbu/local-config": "workspace:^",
+		"@typescript/native-preview": "7.0.0-dev.20260122.4",
+		"changesets-changelog-clean": "^1.3.0",
+		"concurrently": "^9.2.1",
+		"generate-license-file": "^4.1.1",
+		"nx": "22.5.0",
+		"pathe": "^2.0.3",
+		"repopo": "workspace:^",
+		"rimraf": "^6.1.2",
+		"semver": "^7.7.3",
+		"sort-package-json": "*",
+		"sort-tsconfig": "workspace:^",
+		"syncpack": "14.0.0-alpha.37",
+		"ts-node": "^10.9.2",
+		"tslib": "^2.8.1",
+		"tsx": "^4.21.0",
+		"type-fest": "^5.4.1"
+	},
+	"packageManager": "pnpm@10.24.0",
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"pnpm": {
+		"peerDependencyRules": {
+			"allowAny": [
+				"@aws-sdk/*"
+			],
+			"ignoreMissing": [
+				"@aws-sdk/*",
+				"@octokit/core"
+			]
+		},
+		"onlyBuiltDependencies": [
+			"@biomejs/biome",
+			"@parcel/watcher",
+			"@tailwindcss/oxide",
+			"better-sqlite3",
+			"core-js",
+			"core-js-pure",
+			"dtrace-provider",
+			"esbuild",
+			"msw",
+			"nx",
+			"protobufjs",
+			"re2",
+			"sharp",
+			"unrs-resolver",
+			"yarn"
+		],
+		"updateConfig": {
+			"ignoreDependencies": [
+				"@types/node"
+			]
+		},
+		"overrides": {
+			"oclif>@aws-sdk/client-cloudfront": "npm:empty-npm-package@1.0.0",
+			"oclif>@aws-sdk/client-s3": "npm:empty-npm-package@1.0.0"
+		}
+	},
+	"nx": {
+		"includedScripts": [
+			"deps:sync"
+		],
+		"targets": {
+			"check": {
+				"dependsOn": [
+					"check:all",
+					"^check"
+				],
+				"cache": true
+			},
+			"check:all": {
+				"dependsOn": [
+					"check:deps",
+					"check:format",
+					"check:policy",
+					"check:references",
+					"lint"
+				],
+				"cache": true
+			},
+			"check:format": {
+				"executor": "nx:run-script",
+				"options": {
+					"script": "check:format"
+				},
+				"inputs": [
+					"{workspaceRoot}/**/*.{ts,tsx,js,jsx,mjs,cjs,mts,cts,json,jsonc,md}",
+					"!{workspaceRoot}/**/node_modules/**",
+					"!{workspaceRoot}/**/dist/**",
+					"!{workspaceRoot}/**/esm/**",
+					"{workspaceRoot}/biome.jsonc",
+					"{workspaceRoot}/config/biome/*.jsonc"
+				],
+				"cache": true
+			},
+			"lint": {
+				"executor": "nx:run-script",
+				"options": {
+					"script": "lint"
+				},
+				"inputs": [
+					"{workspaceRoot}/**/*.{ts,tsx,js,jsx,mjs,cjs,mts,cts}",
+					"!{workspaceRoot}/**/node_modules/**",
+					"!{workspaceRoot}/**/dist/**",
+					"!{workspaceRoot}/**/esm/**",
+					"{workspaceRoot}/biome.jsonc",
+					"{workspaceRoot}/config/biome/*.jsonc"
+				],
+				"cache": true
+			},
+			"check:deps": {
+				"executor": "nx:run-script",
+				"options": {
+					"script": "check:deps"
+				},
+				"inputs": [
+					"{workspaceRoot}/package.json",
+					"{workspaceRoot}/packages/*/package.json",
+					"{workspaceRoot}/syncpack.config.cjs",
+					"{workspaceRoot}/pnpm-lock.yaml"
+				],
+				"cache": true
+			},
+			"check:policy": {
+				"executor": "nx:run-script",
+				"dependsOn": [
+					"sort-tsconfig:build:compile"
+				],
+				"options": {
+					"script": "check:policy"
+				},
+				"inputs": [
+					"{workspaceRoot}/**/*",
+					"!{workspaceRoot}/**/node_modules/**",
+					"!{workspaceRoot}/**/dist/**",
+					"!{workspaceRoot}/**/esm/**",
+					"{workspaceRoot}/repopo.config.ts"
+				],
+				"cache": true
+			},
+			"check:references": {
+				"executor": "nx:run-script",
+				"options": {
+					"script": "check:references"
+				},
+				"inputs": [
+					"{workspaceRoot}/package.json",
+					"{workspaceRoot}/packages/*/package.json",
+					"{workspaceRoot}/packages/*/tsconfig*.json",
+					"{workspaceRoot}/config/tsconfig*.json"
+				],
+				"cache": true
+			},
+			"check:types:native": {
+				"executor": "nx:run-script",
+				"options": {
+					"script": "check:types:native"
+				},
+				"inputs": [
+					"{workspaceRoot}/**/*.{ts,tsx,mts,cts}",
+					"!{workspaceRoot}/**/node_modules/**",
+					"!{workspaceRoot}/**/dist/**",
+					"!{workspaceRoot}/**/esm/**",
+					"{workspaceRoot}/config/tsconfig*.json",
+					"{workspaceRoot}/packages/*/tsconfig*.json"
+				],
+				"cache": true
+			},
+			"clean:root": {
+				"executor": "nx:run-script",
+				"options": {
+					"script": "clean:root"
+				},
+				"cache": false
+			},
+			"deps:sync": {
+				"dependsOn": [
+					"cli:build:compile"
+				],
+				"inputs": [
+					"{workspaceRoot}/package.json",
+					"{workspaceRoot}/packages/*/package.json",
+					"{workspaceRoot}/pnpm-lockfile.yaml"
+				],
+				"cache": true
+			}
+		}
+	}
 }

--- a/packages/cli-api/package.json
+++ b/packages/cli-api/package.json
@@ -1,124 +1,124 @@
 {
-  "name": "@tylerbu/cli-api",
-  "version": "0.10.1",
-  "description": "Base classes and other API helpers for oclif-based CLI projects.",
-  "homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/cli-api#tylerbucli-api",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/cli-api"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./esm/index.d.ts",
-        "default": "./esm/index.js"
-      }
-    },
-    "./loggers/basic": {
-      "import": {
-        "types": "./esm/loggers/basic.d.ts",
-        "default": "./esm/loggers/basic.js"
-      }
-    },
-    "./loggers/consola": {
-      "import": {
-        "types": "./esm/loggers/consola.d.ts",
-        "default": "./esm/loggers/consola.js"
-      }
-    },
-    "./loggers/prefixReporter": {
-      "import": {
-        "types": "./esm/loggers/prefixReporter.d.ts",
-        "default": "./esm/loggers/prefixReporter.js"
-      }
-    }
-  },
-  "types": "./esm/index.d.ts",
-  "files": [
-    "/CHANGELOG.md",
-    "/esm",
-    "!/esm/commands",
-    "!/esm/testConfig.*",
-    "/THIRD-PARTY-LICENSES.txt"
-  ],
-  "scripts": {
-    "api:markdown": "api-documenter markdown -i _temp/api-extractor -o _temp/docs",
-    "b": "nx build",
-    "build:api": "api-extractor run --local",
-    "build:compile": "tsc --project ./tsconfig.json",
-    "check": "pnpm check:format",
-    "check:format": "biome format .",
-    "clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
-    "format": "biome check . --linter-enabled=false --write",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint . --write",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-    "test:coverage": "vitest run test --coverage",
-    "test:vitest": "vitest run test"
-  },
-  "oclif": {
-    "bin": "tylerbu-cli-api",
-    "commands": "./esm/commands",
-    "dirname": "tylerbu-cli-api"
-  },
-  "dependencies": {
-    "@oclif/core": "^4.8.0",
-    "@tylerbu/fundamentals": "workspace:^",
-    "@tylerbu/lilconfig-loader-ts": "workspace:^",
-    "debug": "^4.4.3",
-    "detect-indent": "^7.0.2",
-    "jsonfile": "^6.2.0",
-    "lilconfig": "^3.1.3",
-    "pathe": "^2.0.3",
-    "picocolors": "^1.1.1",
-    "semver": "^7.7.3",
-    "simple-git": "^3.30.0",
-    "sort-package-json": "*",
-    "strip-ansi": "^7.1.2"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@microsoft/api-documenter": "^7.28.1",
-    "@microsoft/api-extractor": "^7.56.0",
-    "@oclif/test": "^4.1.15",
-    "@types/debug": "^4.1.12",
-    "@types/jsonfile": "^6.1.4",
-    "@types/node": "^20.19.25",
-    "@types/semver": "^7.7.1",
-    "@vitest/coverage-v8": "^4.0.18",
-    "concurrently": "^9.2.1",
-    "consola": "^3.4.0",
-    "generate-license-file": "^4.1.1",
-    "oclif": "^4.22.50",
-    "rimraf": "^6.1.2",
-    "tmp-promise": "^3.0.3",
-    "ts-node": "^10.9.2",
-    "tsx": "^4.21.0",
-    "type-fest": "^5.4.1",
-    "typescript": "~5.9.3",
-    "vitest": "^4.0.18"
-  },
-  "peerDependencies": {
-    "consola": "^3.4.0"
-  },
-  "peerDependenciesMeta": {
-    "consola": {
-      "optional": true
-    }
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "nx": {
-    "targets": {
-      "build": {},
-      "test": {},
-      "ci": {}
-    }
-  }
+	"name": "@tylerbu/cli-api",
+	"version": "0.10.1",
+	"description": "Base classes and other API helpers for oclif-based CLI projects.",
+	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/cli-api#tylerbucli-api",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/cli-api"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./esm/index.d.ts",
+				"default": "./esm/index.js"
+			}
+		},
+		"./loggers/basic": {
+			"import": {
+				"types": "./esm/loggers/basic.d.ts",
+				"default": "./esm/loggers/basic.js"
+			}
+		},
+		"./loggers/consola": {
+			"import": {
+				"types": "./esm/loggers/consola.d.ts",
+				"default": "./esm/loggers/consola.js"
+			}
+		},
+		"./loggers/prefixReporter": {
+			"import": {
+				"types": "./esm/loggers/prefixReporter.d.ts",
+				"default": "./esm/loggers/prefixReporter.js"
+			}
+		}
+	},
+	"types": "./esm/index.d.ts",
+	"files": [
+		"/CHANGELOG.md",
+		"/esm",
+		"!/esm/commands",
+		"!/esm/testConfig.*",
+		"/THIRD-PARTY-LICENSES.txt"
+	],
+	"scripts": {
+		"api:markdown": "api-documenter markdown -i _temp/api-extractor -o _temp/docs",
+		"b": "nx build",
+		"build:api": "api-extractor run --local",
+		"build:compile": "tsc --project ./tsconfig.json",
+		"check": "pnpm check:format",
+		"check:format": "biome format .",
+		"clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --write",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"test:coverage": "vitest run test --coverage",
+		"test:vitest": "vitest run test"
+	},
+	"oclif": {
+		"bin": "tylerbu-cli-api",
+		"commands": "./esm/commands",
+		"dirname": "tylerbu-cli-api"
+	},
+	"dependencies": {
+		"@oclif/core": "^4.8.0",
+		"@tylerbu/fundamentals": "workspace:^",
+		"@tylerbu/lilconfig-loader-ts": "workspace:^",
+		"debug": "^4.4.3",
+		"detect-indent": "^7.0.2",
+		"jsonfile": "^6.2.0",
+		"lilconfig": "^3.1.3",
+		"pathe": "^2.0.3",
+		"picocolors": "^1.1.1",
+		"semver": "^7.7.3",
+		"simple-git": "^3.30.0",
+		"sort-package-json": "*",
+		"strip-ansi": "^7.1.2"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@microsoft/api-documenter": "^7.28.1",
+		"@microsoft/api-extractor": "^7.56.0",
+		"@oclif/test": "^4.1.15",
+		"@types/debug": "^4.1.12",
+		"@types/jsonfile": "^6.1.4",
+		"@types/node": "^20.19.25",
+		"@types/semver": "^7.7.1",
+		"@vitest/coverage-v8": "^4.0.18",
+		"concurrently": "^9.2.1",
+		"consola": "^3.4.0",
+		"generate-license-file": "^4.1.1",
+		"oclif": "^4.22.50",
+		"rimraf": "^6.1.2",
+		"tmp-promise": "^3.0.3",
+		"ts-node": "^10.9.2",
+		"tsx": "^4.21.0",
+		"type-fest": "^5.4.1",
+		"typescript": "~5.9.3",
+		"vitest": "^4.0.18"
+	},
+	"peerDependencies": {
+		"consola": "^3.4.0"
+	},
+	"peerDependenciesMeta": {
+		"consola": {
+			"optional": true
+		}
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"nx": {
+		"targets": {
+			"build": {},
+			"test": {},
+			"ci": {}
+		}
+	}
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,157 +1,157 @@
 {
-  "name": "@tylerbu/cli",
-  "version": "0.9.0",
-  "description": "Tyler Butler's personal CLI.",
-  "keywords": [
-    "oclif"
-  ],
-  "homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/cli#tylerbucli",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/cli"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./esm/index.d.ts",
-        "default": "./esm/index.js"
-      }
-    }
-  },
-  "types": "esm/index.d.ts",
-  "bin": {
-    "tbu": "./bin/run.js"
-  },
-  "files": [
-    "/bin",
-    "/CHANGELOG.md",
-    "/esm",
-    "/oclif.manifest.json",
-    "/queries",
-    "/THIRD-PARTY-LICENSES.txt"
-  ],
-  "scripts": {
-    "build:compile": "tsc --project ./tsconfig.json && pnpm build:copy-templates",
-    "build:copy-templates": "copyfiles -u 4 \"src/lib/fluid-repo-overlay/templates/**/*\" esm/lib/fluid-repo-overlay/templates/",
-    "build:generate": "./bin/dev.js snapshot:generate --filepath test/commands/__snapshots__/commands.json",
-    "build:manifest": "oclif manifest",
-    "build:readme": "oclif readme --multi --no-aliases",
-    "check": "pnpm check:format",
-    "check:format": "biome check . --linter-enabled=false",
-    "clean": "concurrently npm:clean:build npm:clean:manifest",
-    "clean:build": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
-    "clean:manifest": "rimraf oclif.manifest.json",
-    "format": "biome check . --linter-enabled=false --write",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint . --write",
-    "postpack": "pnpm clean:manifest",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-    "test": "vitest run",
-    "test:coverage": "vitest run test --coverage",
-    "test:snapshots": "./bin/dev.js snapshot:compare --filepath test/commands/__snapshots__/commands.json",
-    "test:unit": "vitest run"
-  },
-  "oclif": {
-    "additionalHelpFlags": [
-      "-h"
-    ],
-    "additionalVersionFlags": [
-      "-V"
-    ],
-    "bin": "tbu",
-    "commands": "./esm/commands",
-    "devPlugins": [
-      "@oclif/plugin-command-snapshot"
-    ],
-    "dirname": "tbu",
-    "plugins": [
-      "@oclif/plugin-autocomplete",
-      "@oclif/plugin-commands",
-      "@oclif/plugin-help",
-      "@oclif/plugin-not-found",
-      "@oclif/plugin-search",
-      "@oclif/plugin-version",
-      "@oclif/plugin-warn-if-update-available",
-      "@oclif/plugin-which"
-    ],
-    "repositoryPrefix": "<%- repo %>/blob/main/packages/cli/<%- commandPath %>",
-    "topicSeparator": " ",
-    "topics": {
-      "deps": {
-        "description": "Dependency management commands."
-      },
-      "fluid": {
-        "description": "FluidFramework repository tools."
-      },
-      "generate": {
-        "description": "Code and config generation commands."
-      },
-      "git": {
-        "description": "Git-related commands."
-      },
-      "pr": {
-        "description": "GitHub pull request metrics collection and reporting."
-      },
-      "sort": {
-        "description": "Commands to sort config files like tsconfigs."
-      }
-    }
-  },
-  "dependencies": {
-    "@oclif/core": "^4.8.0",
-    "@oclif/plugin-autocomplete": "^3.2.39",
-    "@oclif/plugin-commands": "^4.1.38",
-    "@oclif/plugin-help": "^6.2.36",
-    "@oclif/plugin-not-found": "^3.2.73",
-    "@oclif/plugin-plugins": "^5.4.54",
-    "@oclif/plugin-search": "^1.2.36",
-    "@oclif/plugin-version": "^2.2.36",
-    "@oclif/plugin-warn-if-update-available": "^3.1.53",
-    "@oclif/plugin-which": "^3.2.42",
-    "@tylerbu/cli-api": "workspace:^",
-    "@tylerbu/fundamentals": "workspace:^",
-    "ccl-ts": "^0.2.0",
-    "debug": "^4.4.3",
-    "dill-cli": "workspace:^",
-    "pathe": "^2.0.3",
-    "picocolors": "^1.1.1",
-    "semver": "^7.7.3",
-    "simple-git": "^3.30.0",
-    "strip-ansi": "^7.1.2",
-    "tinyglobby": "^0.2.15"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@oclif/plugin-command-snapshot": "^5.3.8",
-    "@oclif/test": "^4.1.15",
-    "@types/debug": "^4.1.12",
-    "@types/node": "^20.19.25",
-    "@types/semver": "^7.7.1",
-    "@vitest/coverage-v8": "^4.0.18",
-    "concurrently": "^9.2.1",
-    "copyfiles": "^2.4.1",
-    "generate-license-file": "^4.1.1",
-    "oclif": "^4.22.50",
-    "rimraf": "^6.1.2",
-    "sort-package-json": "*",
-    "ts-node": "^10.9.2",
-    "typescript": "~5.9.3",
-    "vitest": "^4.0.18"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "nx": {
-    "targets": {
-      "ci": {},
-      "build": {
-        "executor": "nx:noop"
-      }
-    }
-  }
+	"name": "@tylerbu/cli",
+	"version": "0.9.0",
+	"description": "Tyler Butler's personal CLI.",
+	"keywords": [
+		"oclif"
+	],
+	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/cli#tylerbucli",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/cli"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./esm/index.d.ts",
+				"default": "./esm/index.js"
+			}
+		}
+	},
+	"types": "esm/index.d.ts",
+	"bin": {
+		"tbu": "./bin/run.js"
+	},
+	"files": [
+		"/bin",
+		"/CHANGELOG.md",
+		"/esm",
+		"/oclif.manifest.json",
+		"/queries",
+		"/THIRD-PARTY-LICENSES.txt"
+	],
+	"scripts": {
+		"build:compile": "tsc --project ./tsconfig.json && pnpm build:copy-templates",
+		"build:copy-templates": "copyfiles -u 4 \"src/lib/fluid-repo-overlay/templates/**/*\" esm/lib/fluid-repo-overlay/templates/",
+		"build:generate": "./bin/dev.js snapshot:generate --filepath test/commands/__snapshots__/commands.json",
+		"build:manifest": "oclif manifest",
+		"build:readme": "oclif readme --multi --no-aliases",
+		"check": "pnpm check:format",
+		"check:format": "biome check . --linter-enabled=false",
+		"clean": "concurrently npm:clean:build npm:clean:manifest",
+		"clean:build": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
+		"clean:manifest": "rimraf oclif.manifest.json",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --write",
+		"postpack": "pnpm clean:manifest",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"test": "vitest run",
+		"test:coverage": "vitest run test --coverage",
+		"test:snapshots": "./bin/dev.js snapshot:compare --filepath test/commands/__snapshots__/commands.json",
+		"test:unit": "vitest run"
+	},
+	"oclif": {
+		"additionalHelpFlags": [
+			"-h"
+		],
+		"additionalVersionFlags": [
+			"-V"
+		],
+		"bin": "tbu",
+		"commands": "./esm/commands",
+		"devPlugins": [
+			"@oclif/plugin-command-snapshot"
+		],
+		"dirname": "tbu",
+		"plugins": [
+			"@oclif/plugin-autocomplete",
+			"@oclif/plugin-commands",
+			"@oclif/plugin-help",
+			"@oclif/plugin-not-found",
+			"@oclif/plugin-search",
+			"@oclif/plugin-version",
+			"@oclif/plugin-warn-if-update-available",
+			"@oclif/plugin-which"
+		],
+		"repositoryPrefix": "<%- repo %>/blob/main/packages/cli/<%- commandPath %>",
+		"topicSeparator": " ",
+		"topics": {
+			"deps": {
+				"description": "Dependency management commands."
+			},
+			"fluid": {
+				"description": "FluidFramework repository tools."
+			},
+			"generate": {
+				"description": "Code and config generation commands."
+			},
+			"git": {
+				"description": "Git-related commands."
+			},
+			"pr": {
+				"description": "GitHub pull request metrics collection and reporting."
+			},
+			"sort": {
+				"description": "Commands to sort config files like tsconfigs."
+			}
+		}
+	},
+	"dependencies": {
+		"@oclif/core": "^4.8.0",
+		"@oclif/plugin-autocomplete": "^3.2.39",
+		"@oclif/plugin-commands": "^4.1.38",
+		"@oclif/plugin-help": "^6.2.36",
+		"@oclif/plugin-not-found": "^3.2.73",
+		"@oclif/plugin-plugins": "^5.4.54",
+		"@oclif/plugin-search": "^1.2.36",
+		"@oclif/plugin-version": "^2.2.36",
+		"@oclif/plugin-warn-if-update-available": "^3.1.53",
+		"@oclif/plugin-which": "^3.2.42",
+		"@tylerbu/cli-api": "workspace:^",
+		"@tylerbu/fundamentals": "workspace:^",
+		"ccl-ts": "^0.2.0",
+		"debug": "^4.4.3",
+		"dill-cli": "workspace:^",
+		"pathe": "^2.0.3",
+		"picocolors": "^1.1.1",
+		"semver": "^7.7.3",
+		"simple-git": "^3.30.0",
+		"strip-ansi": "^7.1.2",
+		"tinyglobby": "^0.2.15"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@oclif/plugin-command-snapshot": "^5.3.8",
+		"@oclif/test": "^4.1.15",
+		"@types/debug": "^4.1.12",
+		"@types/node": "^20.19.25",
+		"@types/semver": "^7.7.1",
+		"@vitest/coverage-v8": "^4.0.18",
+		"concurrently": "^9.2.1",
+		"copyfiles": "^2.4.1",
+		"generate-license-file": "^4.1.1",
+		"oclif": "^4.22.50",
+		"rimraf": "^6.1.2",
+		"sort-package-json": "*",
+		"ts-node": "^10.9.2",
+		"typescript": "~5.9.3",
+		"vitest": "^4.0.18"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"nx": {
+		"targets": {
+			"ci": {},
+			"build": {
+				"executor": "nx:noop"
+			}
+		}
+	}
 }

--- a/packages/dill-cli/package.json
+++ b/packages/dill-cli/package.json
@@ -1,149 +1,149 @@
 {
-  "name": "dill-cli",
-  "version": "0.4.1",
-  "description": "Command-line (CLI) program to download and optionally decompress gzipped files.",
-  "keywords": [
-    "download",
-    "ci",
-    "tar",
-    "gzip",
-    "decompress"
-  ],
-  "homepage": "https://dill.tylerbutler.com/",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/dill-cli"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "types": "./esm/index.d.ts",
-      "import": "./esm/index.js"
-    },
-    "./command": {
-      "types": "./esm/commands/download.d.ts",
-      "import": "./esm/commands/download.js"
-    }
-  },
-  "types": "esm/index.d.ts",
-  "bin": {
-    "dill": "./bin/run.js"
-  },
-  "files": [
-    "/bin",
-    "/CHANGELOG.md",
-    "/esm",
-    "/oclif.manifest.json",
-    "/THIRD-PARTY-LICENSES.txt"
-  ],
-  "scripts": {
-    "build:compile": "tsc --project ./tsconfig.json",
-    "build:manifest": "oclif manifest",
-    "build:readme": "concurrently npm:readme:*",
-    "check": "concurrently npm:check:format",
-    "check:format": "biome check . --linter-enabled=false",
-    "check:snapshot": "./bin/dev.js snapshot:compare --filepath test/commands/__snapshots__/commands.json",
-    "clean": "concurrently npm:clean:build npm:clean:manifest",
-    "clean:build": "rimraf esm *.tsbuildinfo *.done.build.log",
-    "clean:manifest": "rimraf oclif.manifest.json",
-    "dill": "./bin/dev.js",
-    "format": "biome check . --linter-enabled=false --write",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint . --write",
-    "postpack": "pnpm clean:manifest",
-    "readme:docs": "oclif readme --no-aliases --readme-path=../dill-docs/src/content/docs/cli-reference.md",
-    "readme:main": "oclif readme --no-aliases",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-    "start": "serve ./test/data --listen 8080",
-    "test:coverage": "vitest run test --coverage",
-    "test:snapshots": "pnpm update:test-snapshots",
-    "test:vitest": "vitest run test",
-    "update:test-snapshots": "vitest run test -u"
-  },
-  "oclif": {
-    "additionalHelpFlags": [
-      "-h"
-    ],
-    "additionalVersionFlags": [
-      "-V"
-    ],
-    "bin": "dill",
-    "commands": {
-      "strategy": "single",
-      "target": "./esm/commands/download.js"
-    },
-    "devPlugins": [],
-    "dirname": "dill",
-    "flexibleTaxonomy": true,
-    "helpOptions": {
-      "hideAliasesFromRoot": true,
-      "hideCommandSummaryInDescription": true,
-      "showFlagNameInTitle": false,
-      "showFlagOptionsInTitle": true,
-      "stripAnsi": true,
-      "usageHeader": "CUSTOM USAGE HEADER"
-    },
-    "plugins": [],
-    "repositoryPrefix": "<%- repo %>/blob/main/packages/dill-cli/<%- commandPath %>"
-  },
-  "dependencies": {
-    "@oclif/core": "^4.8.0",
-    "@oclif/plugin-help": "^6.2.36",
-    "@tinyhttp/content-disposition": "^2.2.2",
-    "@tylerbu/cli-api": "workspace:^",
-    "effection": "^4.0.0",
-    "fflate": "^0.8.2",
-    "file-type": "^21.3.0",
-    "mime": "^4.1.0",
-    "nanotar": "^0.3.0",
-    "pathe": "^2.0.3",
-    "whatwg-mimetype": "^5.0.0"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@microsoft/api-extractor": "^7.56.0",
-    "@oclif/plugin-command-snapshot": "^5.3.8",
-    "@oclif/test": "^4.1.15",
-    "@types/debug": "^4.1.12",
-    "@types/jsonfile": "^6.1.4",
-    "@types/node": "^20.19.25",
-    "@types/semver": "^7.7.1",
-    "@types/serve-handler": "^6.1.4",
-    "@types/tmp": "^0.2.6",
-    "@types/whatwg-mimetype": "^3.0.2",
-    "@vitest/coverage-v8": "^4.0.18",
-    "generate-license-file": "^4.1.1",
-    "get-port-please": "^3.2.0",
-    "jsonfile": "^6.2.0",
-    "msw": "^2.12.3",
-    "oclif": "^4.22.50",
-    "rimraf": "^6.1.2",
-    "serve": "^14.2.5",
-    "serve-handler": "^6.1.6",
-    "sort-package-json": "*",
-    "start-server-and-test": "^2.1.3",
-    "tmp-promise": "^3.0.3",
-    "ts-node": "^10.9.2",
-    "tsx": "^4.21.0",
-    "type-fest": "^5.4.1",
-    "typescript": "~5.9.3",
-    "unionfs": "^4.6.0",
-    "vitest": "^4.0.18"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "nx:noop"
-      },
-      "test": {},
-      "ci": {}
-    }
-  }
+	"name": "dill-cli",
+	"version": "0.4.1",
+	"description": "Command-line (CLI) program to download and optionally decompress gzipped files.",
+	"keywords": [
+		"download",
+		"ci",
+		"tar",
+		"gzip",
+		"decompress"
+	],
+	"homepage": "https://dill.tylerbutler.com/",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/dill-cli"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./esm/index.d.ts",
+			"import": "./esm/index.js"
+		},
+		"./command": {
+			"types": "./esm/commands/download.d.ts",
+			"import": "./esm/commands/download.js"
+		}
+	},
+	"types": "esm/index.d.ts",
+	"bin": {
+		"dill": "./bin/run.js"
+	},
+	"files": [
+		"/bin",
+		"/CHANGELOG.md",
+		"/esm",
+		"/oclif.manifest.json",
+		"/THIRD-PARTY-LICENSES.txt"
+	],
+	"scripts": {
+		"build:compile": "tsc --project ./tsconfig.json",
+		"build:manifest": "oclif manifest",
+		"build:readme": "concurrently npm:readme:*",
+		"check": "concurrently npm:check:format",
+		"check:format": "biome check . --linter-enabled=false",
+		"check:snapshot": "./bin/dev.js snapshot:compare --filepath test/commands/__snapshots__/commands.json",
+		"clean": "concurrently npm:clean:build npm:clean:manifest",
+		"clean:build": "rimraf esm *.tsbuildinfo *.done.build.log",
+		"clean:manifest": "rimraf oclif.manifest.json",
+		"dill": "./bin/dev.js",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --write",
+		"postpack": "pnpm clean:manifest",
+		"readme:docs": "oclif readme --no-aliases --readme-path=../dill-docs/src/content/docs/cli-reference.md",
+		"readme:main": "oclif readme --no-aliases",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"start": "serve ./test/data --listen 8080",
+		"test:coverage": "vitest run test --coverage",
+		"test:snapshots": "pnpm update:test-snapshots",
+		"test:vitest": "vitest run test",
+		"update:test-snapshots": "vitest run test -u"
+	},
+	"oclif": {
+		"additionalHelpFlags": [
+			"-h"
+		],
+		"additionalVersionFlags": [
+			"-V"
+		],
+		"bin": "dill",
+		"commands": {
+			"strategy": "single",
+			"target": "./esm/commands/download.js"
+		},
+		"devPlugins": [],
+		"dirname": "dill",
+		"flexibleTaxonomy": true,
+		"helpOptions": {
+			"hideAliasesFromRoot": true,
+			"hideCommandSummaryInDescription": true,
+			"showFlagNameInTitle": false,
+			"showFlagOptionsInTitle": true,
+			"stripAnsi": true,
+			"usageHeader": "CUSTOM USAGE HEADER"
+		},
+		"plugins": [],
+		"repositoryPrefix": "<%- repo %>/blob/main/packages/dill-cli/<%- commandPath %>"
+	},
+	"dependencies": {
+		"@oclif/core": "^4.8.0",
+		"@oclif/plugin-help": "^6.2.36",
+		"@tinyhttp/content-disposition": "^2.2.2",
+		"@tylerbu/cli-api": "workspace:^",
+		"effection": "^4.0.0",
+		"fflate": "^0.8.2",
+		"file-type": "^21.3.0",
+		"mime": "^4.1.0",
+		"nanotar": "^0.3.0",
+		"pathe": "^2.0.3",
+		"whatwg-mimetype": "^5.0.0"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@microsoft/api-extractor": "^7.56.0",
+		"@oclif/plugin-command-snapshot": "^5.3.8",
+		"@oclif/test": "^4.1.15",
+		"@types/debug": "^4.1.12",
+		"@types/jsonfile": "^6.1.4",
+		"@types/node": "^20.19.25",
+		"@types/semver": "^7.7.1",
+		"@types/serve-handler": "^6.1.4",
+		"@types/tmp": "^0.2.6",
+		"@types/whatwg-mimetype": "^3.0.2",
+		"@vitest/coverage-v8": "^4.0.18",
+		"generate-license-file": "^4.1.1",
+		"get-port-please": "^3.2.0",
+		"jsonfile": "^6.2.0",
+		"msw": "^2.12.3",
+		"oclif": "^4.22.50",
+		"rimraf": "^6.1.2",
+		"serve": "^14.2.5",
+		"serve-handler": "^6.1.6",
+		"sort-package-json": "*",
+		"start-server-and-test": "^2.1.3",
+		"tmp-promise": "^3.0.3",
+		"ts-node": "^10.9.2",
+		"tsx": "^4.21.0",
+		"type-fest": "^5.4.1",
+		"typescript": "~5.9.3",
+		"unionfs": "^4.6.0",
+		"vitest": "^4.0.18"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"nx": {
+		"targets": {
+			"build": {
+				"executor": "nx:noop"
+			},
+			"test": {},
+			"ci": {}
+		}
+	}
 }

--- a/packages/dill-docs/package.json
+++ b/packages/dill-docs/package.json
@@ -1,55 +1,55 @@
 {
-  "name": "dill-docs",
-  "version": "0.0.1",
-  "private": true,
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/dill-docs"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "scripts": {
-    "astro": "astro",
-    "b": "nx build",
-    "build:site": "astro build",
-    "check:astro": "astro check",
-    "clean": "rimraf dist *.tsbuildinfo *.done.build.log .astro .netlify",
-    "dev": "astro dev",
-    "preview": "astro preview",
-    "start": "astro dev"
-  },
-  "dependencies": {
-    "@astrojs/check": "^0.9.6",
-    "@astrojs/netlify": "^6.6.3",
-    "@astrojs/starlight": "^0.37.0",
-    "@fontsource/ibm-plex-serif": "^5.2.7",
-    "@fontsource/metropolis": "^5.2.5",
-    "@fontsource/open-sans": "^5.2.7",
-    "astro": "^5.17.1",
-    "dill-cli": "workspace:^",
-    "sharp": "^0.34.5",
-    "starlight-heading-badges": "^0.6.1",
-    "starlight-links-validator": "^0.19.1",
-    "starlight-package-managers": "^0.12.0",
-    "starlight-typedoc": "^0.21.4",
-    "typedoc": "^0.28.15",
-    "typedoc-plugin-frontmatter": "^1.3.1",
-    "typedoc-plugin-markdown": "^4.9.0",
-    "typedoc-plugin-mdn-links": "^5.1.0",
-    "typescript": "~5.9.3",
-    "zod": "^4.3.5"
-  },
-  "devDependencies": {
-    "@fec/remark-a11y-emoji": "^4.0.2",
-    "@hashicorp/platform-remark-plugins": "^0.2.1"
-  },
-  "nx": {
-    "targets": {
-      "build": {},
-      "ci": {}
-    }
-  }
+	"name": "dill-docs",
+	"version": "0.0.1",
+	"private": true,
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/dill-docs"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"scripts": {
+		"astro": "astro",
+		"b": "nx build",
+		"build:site": "astro build",
+		"check:astro": "astro check",
+		"clean": "rimraf dist *.tsbuildinfo *.done.build.log .astro .netlify",
+		"dev": "astro dev",
+		"preview": "astro preview",
+		"start": "astro dev"
+	},
+	"dependencies": {
+		"@astrojs/check": "^0.9.6",
+		"@astrojs/netlify": "^6.6.3",
+		"@astrojs/starlight": "^0.37.0",
+		"@fontsource/ibm-plex-serif": "^5.2.7",
+		"@fontsource/metropolis": "^5.2.5",
+		"@fontsource/open-sans": "^5.2.7",
+		"astro": "^5.17.1",
+		"dill-cli": "workspace:^",
+		"sharp": "^0.34.5",
+		"starlight-heading-badges": "^0.6.1",
+		"starlight-links-validator": "^0.19.1",
+		"starlight-package-managers": "^0.12.0",
+		"starlight-typedoc": "^0.21.4",
+		"typedoc": "^0.28.15",
+		"typedoc-plugin-frontmatter": "^1.3.1",
+		"typedoc-plugin-markdown": "^4.9.0",
+		"typedoc-plugin-mdn-links": "^5.1.0",
+		"typescript": "~5.9.3",
+		"zod": "^4.3.5"
+	},
+	"devDependencies": {
+		"@fec/remark-a11y-emoji": "^4.0.2",
+		"@hashicorp/platform-remark-plugins": "^0.2.1"
+	},
+	"nx": {
+		"targets": {
+			"build": {},
+			"ci": {}
+		}
+	}
 }

--- a/packages/fundamentals/package.json
+++ b/packages/fundamentals/package.json
@@ -1,83 +1,83 @@
 {
-  "name": "@tylerbu/fundamentals",
-  "version": "0.3.0",
-  "description": "Fundamental functions and classes that I often need in my projects. Zero dependencies.",
-  "homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/fundamentals#tylerbufundamentals",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/fundamentals"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./esm/index.d.ts",
-        "default": "./esm/index.js"
-      }
-    },
-    "./git": {
-      "import": {
-        "types": "./esm/git.d.ts",
-        "default": "./esm/git.js"
-      }
-    },
-    "./set": {
-      "import": {
-        "types": "./esm/set.d.ts",
-        "default": "./esm/set.js"
-      }
-    }
-  },
-  "types": "./esm/index.d.ts",
-  "files": [
-    "esm"
-  ],
-  "scripts": {
-    "build:api": "concurrently npm:docs:api:*",
-    "build:compile": "tsc --project ./tsconfig.json",
-    "build:docs": "typedoc",
-    "check": "pnpm check:format",
-    "check:format": "biome format .",
-    "clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
-    "docs:api:array": "api-extractor run --local --config api-extractor.array.json",
-    "docs:api:git": "api-extractor run --local --config api-extractor.git.json",
-    "docs:api:main": "api-extractor run --local",
-    "docs:api:set": "api-extractor run --local --config api-extractor.set.json",
-    "docs:markdown": "api-documenter markdown -i _temp/api-extractor -o _temp/docs",
-    "format": "biome check . --linter-enabled=false --write",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint . --apply",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-    "test": "vitest run test",
-    "test:coverage": "vitest run test --coverage"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@microsoft/api-documenter": "^7.28.1",
-    "@microsoft/api-extractor": "^7.56.0",
-    "@types/node": "^20.19.25",
-    "@vitest/coverage-v8": "^4.0.18",
-    "concurrently": "^9.2.1",
-    "pathe": "^2.0.3",
-    "rimraf": "^6.1.2",
-    "typedoc": "^0.28.15",
-    "typedoc-plugin-markdown": "^4.9.0",
-    "typescript": "~5.9.3",
-    "vitest": "^4.0.18"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "nx:noop"
-      },
-      "ci": {}
-    }
-  }
+	"name": "@tylerbu/fundamentals",
+	"version": "0.3.0",
+	"description": "Fundamental functions and classes that I often need in my projects. Zero dependencies.",
+	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/fundamentals#tylerbufundamentals",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/fundamentals"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./esm/index.d.ts",
+				"default": "./esm/index.js"
+			}
+		},
+		"./git": {
+			"import": {
+				"types": "./esm/git.d.ts",
+				"default": "./esm/git.js"
+			}
+		},
+		"./set": {
+			"import": {
+				"types": "./esm/set.d.ts",
+				"default": "./esm/set.js"
+			}
+		}
+	},
+	"types": "./esm/index.d.ts",
+	"files": [
+		"esm"
+	],
+	"scripts": {
+		"build:api": "concurrently npm:docs:api:*",
+		"build:compile": "tsc --project ./tsconfig.json",
+		"build:docs": "typedoc",
+		"check": "pnpm check:format",
+		"check:format": "biome format .",
+		"clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
+		"docs:api:array": "api-extractor run --local --config api-extractor.array.json",
+		"docs:api:git": "api-extractor run --local --config api-extractor.git.json",
+		"docs:api:main": "api-extractor run --local",
+		"docs:api:set": "api-extractor run --local --config api-extractor.set.json",
+		"docs:markdown": "api-documenter markdown -i _temp/api-extractor -o _temp/docs",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --apply",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"test": "vitest run test",
+		"test:coverage": "vitest run test --coverage"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@microsoft/api-documenter": "^7.28.1",
+		"@microsoft/api-extractor": "^7.56.0",
+		"@types/node": "^20.19.25",
+		"@vitest/coverage-v8": "^4.0.18",
+		"concurrently": "^9.2.1",
+		"pathe": "^2.0.3",
+		"rimraf": "^6.1.2",
+		"typedoc": "^0.28.15",
+		"typedoc-plugin-markdown": "^4.9.0",
+		"typescript": "~5.9.3",
+		"vitest": "^4.0.18"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"nx": {
+		"targets": {
+			"build": {
+				"executor": "nx:noop"
+			},
+			"ci": {}
+		}
+	}
 }

--- a/packages/levee-client/package.json
+++ b/packages/levee-client/package.json
@@ -1,88 +1,88 @@
 {
-  "name": "@tylerbu/levee-client",
-  "version": "0.0.2",
-  "private": true,
-  "description": "Client for the Levee Fluid Framework service.",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/levee-client"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "sideEffects": false,
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./lib/public.d.ts",
-        "default": "./lib/index.js"
-      }
-    }
-  },
-  "main": "lib/index.js",
-  "types": "lib/public.d.ts",
-  "scripts": {
-    "b": "nx build",
-    "build:api": "api-extractor run --local",
-    "build:compile": "tsc",
-    "check": "pnpm check:format",
-    "check:format": "biome format .",
-    "clean": "rimraf --glob esm \"**/*.tsbuildinfo\" \"**/*.build.log\" _api-extractor-temp _temp nyc",
-    "format": "biome check . --linter-enabled=false --write",
-    "lint": "biome lint",
-    "lint:fix": "biome lint --write",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-    "start": "pm2 start -n tinylicious dist/index.js",
-    "start:debug": "node --inspect=0.0.0.0:9229 dist/index.js",
-    "stop": "pm2 stop tinylicious",
-    "test:coverage": "vitest run --coverage test",
-    "test:mocha": "mocha --recursive dist/test",
-    "test:vitest": "vitest run test"
-  },
-  "dependencies": {
-    "@fluidframework/container-definitions": "~2.42.0",
-    "@fluidframework/container-loader": "~2.42.0",
-    "@fluidframework/core-interfaces": "~2.42.0",
-    "@fluidframework/core-utils": "~2.42.0",
-    "@fluidframework/driver-definitions": "~2.42.0",
-    "@fluidframework/driver-utils": "~2.42.0",
-    "@fluidframework/fluid-static": "~2.42.0",
-    "@fluidframework/map": "~2.42.0",
-    "@fluidframework/routerlicious-driver": "~2.42.0",
-    "@fluidframework/runtime-utils": "~2.42.0",
-    "@fluidframework/telemetry-utils": "~2.42.0",
-    "@fluidframework/tinylicious-driver": "~2.42.0"
-  },
-  "devDependencies": {
-    "@arethetypeswrong/cli": "^0.18.2",
-    "@biomejs/biome": "2.3.8",
-    "@fluidframework/aqueduct": "~2.42.0",
-    "@fluidframework/container-runtime": "~2.42.0",
-    "@fluidframework/container-runtime-definitions": "~2.42.0",
-    "@fluidframework/shared-object-base": "~2.42.0",
-    "@fluidframework/test-utils": "~2.42.0",
-    "@microsoft/api-extractor": "^7.56.0",
-    "@tsconfig/node18": "^18.2.6",
-    "@types/mocha": "^10.0.10",
-    "@types/node": "^20.19.25",
-    "@vitest/coverage-v8": "^4.0.18",
-    "concurrently": "^9.2.1",
-    "copyfiles": "^2.4.1",
-    "eslint": "^9.39.1",
-    "mocha": "^11.7.5",
-    "rimraf": "^6.1.2",
-    "start-server-and-test": "^2.1.3",
-    "tinylicious": "^6.0.0",
-    "typescript": "~5.9.3",
-    "vitest": "^4.0.18"
-  },
-  "nx": {
-    "targets": {
-      "build": {},
-      "test": {},
-      "ci": {}
-    }
-  }
+	"name": "@tylerbu/levee-client",
+	"version": "0.0.2",
+	"private": true,
+	"description": "Client for the Levee Fluid Framework service.",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/levee-client"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"sideEffects": false,
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./lib/public.d.ts",
+				"default": "./lib/index.js"
+			}
+		}
+	},
+	"main": "lib/index.js",
+	"types": "lib/public.d.ts",
+	"scripts": {
+		"b": "nx build",
+		"build:api": "api-extractor run --local",
+		"build:compile": "tsc",
+		"check": "pnpm check:format",
+		"check:format": "biome format .",
+		"clean": "rimraf --glob esm \"**/*.tsbuildinfo\" \"**/*.build.log\" _api-extractor-temp _temp nyc",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint",
+		"lint:fix": "biome lint --write",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"start": "pm2 start -n tinylicious dist/index.js",
+		"start:debug": "node --inspect=0.0.0.0:9229 dist/index.js",
+		"stop": "pm2 stop tinylicious",
+		"test:coverage": "vitest run --coverage test",
+		"test:mocha": "mocha --recursive dist/test",
+		"test:vitest": "vitest run test"
+	},
+	"dependencies": {
+		"@fluidframework/container-definitions": "~2.33.2",
+		"@fluidframework/container-loader": "~2.33.2",
+		"@fluidframework/core-interfaces": "~2.33.2",
+		"@fluidframework/core-utils": "~2.33.2",
+		"@fluidframework/driver-definitions": "~2.33.2",
+		"@fluidframework/driver-utils": "~2.33.2",
+		"@fluidframework/fluid-static": "~2.33.2",
+		"@fluidframework/map": "~2.33.2",
+		"@fluidframework/routerlicious-driver": "~2.33.2",
+		"@fluidframework/runtime-utils": "~2.33.2",
+		"@fluidframework/telemetry-utils": "~2.33.2",
+		"@fluidframework/tinylicious-driver": "~2.33.2"
+	},
+	"devDependencies": {
+		"@arethetypeswrong/cli": "^0.18.2",
+		"@biomejs/biome": "2.3.8",
+		"@fluidframework/aqueduct": "~2.42.0",
+		"@fluidframework/container-runtime": "~2.42.0",
+		"@fluidframework/container-runtime-definitions": "~2.42.0",
+		"@fluidframework/shared-object-base": "~2.42.0",
+		"@fluidframework/test-utils": "~2.42.0",
+		"@microsoft/api-extractor": "^7.56.0",
+		"@tsconfig/node18": "^18.2.6",
+		"@types/mocha": "^10.0.10",
+		"@types/node": "^20.19.25",
+		"@vitest/coverage-v8": "^4.0.17",
+		"concurrently": "^9.2.1",
+		"copyfiles": "^2.4.1",
+		"eslint": "^9.39.1",
+		"mocha": "^11.7.5",
+		"rimraf": "^6.1.2",
+		"start-server-and-test": "^2.1.3",
+		"tinylicious": "^6.0.0",
+		"typescript": "~5.9.3",
+		"vitest": "^4.0.17"
+	},
+	"nx": {
+		"targets": {
+			"build": {},
+			"test": {},
+			"ci": {}
+		}
+	}
 }

--- a/packages/lilconfig-loader-ts/package.json
+++ b/packages/lilconfig-loader-ts/package.json
@@ -1,68 +1,68 @@
 {
-  "name": "@tylerbu/lilconfig-loader-ts",
-  "version": "0.1.3",
-  "description": "A loader that enables loading TypeScript files in lilconfig.",
-  "homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/cli-api#tylerbucli-api",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/lilconfig-loader-ts"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./esm/index.d.ts",
-        "default": "./esm/index.js"
-      }
-    }
-  },
-  "types": "./esm/index.d.ts",
-  "files": [
-    "/CHANGELOG.md",
-    "/esm",
-    "/THIRD-PARTY-LICENSES.txt"
-  ],
-  "scripts": {
-    "api:markdown": "api-documenter markdown -i _temp/api-extractor -o _temp/docs",
-    "b": "nx build",
-    "build:api": "api-extractor run --local",
-    "build:compile": "tsc --project ./tsconfig.json",
-    "check": "pnpm check:format",
-    "check:format": "biome format .",
-    "clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
-    "format": "biome check . --linter-enabled=false --write",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint . --write",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs"
-  },
-  "dependencies": {
-    "jiti": "^2.6.1"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@microsoft/api-documenter": "^7.28.1",
-    "@microsoft/api-extractor": "^7.56.0",
-    "@types/node": "^20.19.25",
-    "concurrently": "^9.2.1",
-    "generate-license-file": "^4.1.1",
-    "rimraf": "^6.1.2",
-    "typescript": "~5.9.3",
-    "vitest": "^4.0.18"
-  },
-  "peerDependencies": {
-    "lilconfig": "^3.1.3"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "nx": {
-    "targets": {
-      "build": {},
-      "ci": {}
-    }
-  }
+	"name": "@tylerbu/lilconfig-loader-ts",
+	"version": "0.1.3",
+	"description": "A loader that enables loading TypeScript files in lilconfig.",
+	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/cli-api#tylerbucli-api",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/lilconfig-loader-ts"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./esm/index.d.ts",
+				"default": "./esm/index.js"
+			}
+		}
+	},
+	"types": "./esm/index.d.ts",
+	"files": [
+		"/CHANGELOG.md",
+		"/esm",
+		"/THIRD-PARTY-LICENSES.txt"
+	],
+	"scripts": {
+		"api:markdown": "api-documenter markdown -i _temp/api-extractor -o _temp/docs",
+		"b": "nx build",
+		"build:api": "api-extractor run --local",
+		"build:compile": "tsc --project ./tsconfig.json",
+		"check": "pnpm check:format",
+		"check:format": "biome format .",
+		"clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --write",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs"
+	},
+	"dependencies": {
+		"jiti": "^2.6.1"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@microsoft/api-documenter": "^7.28.1",
+		"@microsoft/api-extractor": "^7.56.0",
+		"@types/node": "^20.19.25",
+		"concurrently": "^9.2.1",
+		"generate-license-file": "^4.1.1",
+		"rimraf": "^6.1.2",
+		"typescript": "~5.9.3",
+		"vitest": "^4.0.18"
+	},
+	"peerDependencies": {
+		"lilconfig": "^3.1.3"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"nx": {
+		"targets": {
+			"build": {},
+			"ci": {}
+		}
+	}
 }

--- a/packages/rehype-footnotes/package.json
+++ b/packages/rehype-footnotes/package.json
@@ -1,73 +1,73 @@
 {
-  "name": "rehype-footnotes",
-  "version": "0.1.2",
-  "description": "Rehype plugin to transform GFM footnotes for Littlefoot.js integration",
-  "homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/rehype-footnotes#rehype-footnotes",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/rehype-footnotes"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./esm/index.d.ts",
-        "default": "./esm/index.js"
-      }
-    }
-  },
-  "types": "./esm/index.d.ts",
-  "files": [
-    "esm"
-  ],
-  "scripts": {
-    "build:compile": "tsc --project ./tsconfig.json",
-    "check": "pnpm check:format",
-    "check:format": "biome format .",
-    "clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
-    "format": "biome check . --linter-enabled=false --write",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint . --apply",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-    "test": "vitest run test",
-    "test:coverage": "vitest run test --coverage"
-  },
-  "dependencies": {
-    "unified": "^11.0.5",
-    "unist-util-visit": "^5.1.0"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@types/hast": "^3.0.4",
-    "@types/node": "^20.19.25",
-    "@vitest/coverage-v8": "^4.0.18",
-    "rehype": "^13.0.2",
-    "rehype-parse": "^9.0.1",
-    "rehype-stringify": "^10.0.1",
-    "remark": "^15.0.1",
-    "remark-gfm": "^4.0.1",
-    "remark-parse": "^11.0.0",
-    "remark-rehype": "^11.1.2",
-    "rimraf": "^6.1.2",
-    "typescript": "~5.9.3",
-    "vitest": "^4.0.18"
-  },
-  "peerDependencies": {
-    "unified": "^11.0.5"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "nx:noop"
-      },
-      "ci": {}
-    }
-  }
+	"name": "rehype-footnotes",
+	"version": "0.1.2",
+	"description": "Rehype plugin to transform GFM footnotes for Littlefoot.js integration",
+	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/rehype-footnotes#rehype-footnotes",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/rehype-footnotes"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./esm/index.d.ts",
+				"default": "./esm/index.js"
+			}
+		}
+	},
+	"types": "./esm/index.d.ts",
+	"files": [
+		"esm"
+	],
+	"scripts": {
+		"build:compile": "tsc --project ./tsconfig.json",
+		"check": "pnpm check:format",
+		"check:format": "biome format .",
+		"clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --apply",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"test": "vitest run test",
+		"test:coverage": "vitest run test --coverage"
+	},
+	"dependencies": {
+		"unified": "^11.0.5",
+		"unist-util-visit": "^5.1.0"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@types/hast": "^3.0.4",
+		"@types/node": "^20.19.25",
+		"@vitest/coverage-v8": "^4.0.18",
+		"rehype": "^13.0.2",
+		"rehype-parse": "^9.0.1",
+		"rehype-stringify": "^10.0.1",
+		"remark": "^15.0.1",
+		"remark-gfm": "^4.0.1",
+		"remark-parse": "^11.0.0",
+		"remark-rehype": "^11.1.2",
+		"rimraf": "^6.1.2",
+		"typescript": "~5.9.3",
+		"vitest": "^4.0.18"
+	},
+	"peerDependencies": {
+		"unified": "^11.0.5"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"nx": {
+		"targets": {
+			"build": {
+				"executor": "nx:noop"
+			},
+			"ci": {}
+		}
+	}
 }

--- a/packages/remark-lazy-links/package.json
+++ b/packages/remark-lazy-links/package.json
@@ -1,69 +1,69 @@
 {
-  "name": "remark-lazy-links",
-  "version": "0.1.1",
-  "description": "Remark plugin to transform lazy markdown links [*] into numbered references",
-  "homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/remark-lazy-links#remark-lazy-links",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/remark-lazy-links"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./esm/index.d.ts",
-        "default": "./esm/index.js"
-      }
-    }
-  },
-  "types": "./esm/index.d.ts",
-  "files": [
-    "esm"
-  ],
-  "scripts": {
-    "build:compile": "tsc --project ./tsconfig.json",
-    "check": "pnpm check:format",
-    "check:format": "biome format .",
-    "clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
-    "format": "biome check . --linter-enabled=false --write",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint . --apply",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-    "test": "vitest run test",
-    "test:coverage": "vitest run test --coverage"
-  },
-  "dependencies": {
-    "mdast-util-from-markdown": "^2.0.2",
-    "unified": "^11.0.5",
-    "vfile": "^6.0.3"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@types/mdast": "^4.0.4",
-    "@types/node": "^20.19.25",
-    "@vitest/coverage-v8": "^4.0.18",
-    "remark": "^15.0.1",
-    "remark-parse": "^11.0.0",
-    "rimraf": "^6.1.2",
-    "typescript": "~5.9.3",
-    "vitest": "^4.0.18"
-  },
-  "peerDependencies": {
-    "unified": "^11.0.5"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "nx:noop"
-      },
-      "ci": {}
-    }
-  }
+	"name": "remark-lazy-links",
+	"version": "0.1.1",
+	"description": "Remark plugin to transform lazy markdown links [*] into numbered references",
+	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/remark-lazy-links#remark-lazy-links",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/remark-lazy-links"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./esm/index.d.ts",
+				"default": "./esm/index.js"
+			}
+		}
+	},
+	"types": "./esm/index.d.ts",
+	"files": [
+		"esm"
+	],
+	"scripts": {
+		"build:compile": "tsc --project ./tsconfig.json",
+		"check": "pnpm check:format",
+		"check:format": "biome format .",
+		"clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --apply",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"test": "vitest run test",
+		"test:coverage": "vitest run test --coverage"
+	},
+	"dependencies": {
+		"mdast-util-from-markdown": "^2.0.2",
+		"unified": "^11.0.5",
+		"vfile": "^6.0.3"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@types/mdast": "^4.0.4",
+		"@types/node": "^20.19.25",
+		"@vitest/coverage-v8": "^4.0.18",
+		"remark": "^15.0.1",
+		"remark-parse": "^11.0.0",
+		"rimraf": "^6.1.2",
+		"typescript": "~5.9.3",
+		"vitest": "^4.0.18"
+	},
+	"peerDependencies": {
+		"unified": "^11.0.5"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"nx": {
+		"targets": {
+			"build": {
+				"executor": "nx:noop"
+			},
+			"ci": {}
+		}
+	}
 }

--- a/packages/remark-repopo-policies/package.json
+++ b/packages/remark-repopo-policies/package.json
@@ -1,73 +1,73 @@
 {
-  "name": "remark-repopo-policies",
-  "version": "0.1.1",
-  "description": "Remark plugin to generate documentation tables for repopo repository policies",
-  "homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/remark-repopo-policies#remark-repopo-policies",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/remark-repopo-policies"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./esm/index.d.ts",
-        "default": "./esm/index.js"
-      }
-    }
-  },
-  "types": "./esm/index.d.ts",
-  "files": [
-    "esm"
-  ],
-  "scripts": {
-    "build:compile": "tsc --project ./tsconfig.json",
-    "check": "pnpm check:format",
-    "check:format": "biome format .",
-    "clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
-    "format": "biome check . --linter-enabled=false --write",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint . --apply",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-    "test": "vitest run test",
-    "test:coverage": "vitest run test --coverage"
-  },
-  "dependencies": {
-    "mdast-util-to-string": "^4.0.0",
-    "pathe": "^2.0.3",
-    "unified": "^11.0.5",
-    "vfile": "^6.0.3"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@types/mdast": "^4.0.4",
-    "@types/node": "^20.19.25",
-    "@vitest/coverage-v8": "^4.0.18",
-    "remark": "^15.0.1",
-    "remark-gfm": "^4.0.1",
-    "remark-parse": "^11.0.0",
-    "repopo": "workspace:^",
-    "rimraf": "^6.1.2",
-    "typescript": "~5.9.3",
-    "vitest": "^4.0.18"
-  },
-  "peerDependencies": {
-    "repopo": "^0.10.0",
-    "unified": "^11.0.5"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "nx:noop"
-      },
-      "ci": {}
-    }
-  }
+	"name": "remark-repopo-policies",
+	"version": "0.1.1",
+	"description": "Remark plugin to generate documentation tables for repopo repository policies",
+	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/remark-repopo-policies#remark-repopo-policies",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/remark-repopo-policies"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./esm/index.d.ts",
+				"default": "./esm/index.js"
+			}
+		}
+	},
+	"types": "./esm/index.d.ts",
+	"files": [
+		"esm"
+	],
+	"scripts": {
+		"build:compile": "tsc --project ./tsconfig.json",
+		"check": "pnpm check:format",
+		"check:format": "biome format .",
+		"clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --apply",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"test": "vitest run test",
+		"test:coverage": "vitest run test --coverage"
+	},
+	"dependencies": {
+		"mdast-util-to-string": "^4.0.0",
+		"pathe": "^2.0.3",
+		"unified": "^11.0.5",
+		"vfile": "^6.0.3"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@types/mdast": "^4.0.4",
+		"@types/node": "^20.19.25",
+		"@vitest/coverage-v8": "^4.0.18",
+		"remark": "^15.0.1",
+		"remark-gfm": "^4.0.1",
+		"remark-parse": "^11.0.0",
+		"repopo": "workspace:^",
+		"rimraf": "^6.1.2",
+		"typescript": "~5.9.3",
+		"vitest": "^4.0.18"
+	},
+	"peerDependencies": {
+		"repopo": "^0.10.0",
+		"unified": "^11.0.5"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"nx": {
+		"targets": {
+			"build": {
+				"executor": "nx:noop"
+			},
+			"ci": {}
+		}
+	}
 }

--- a/packages/remark-shift-headings/package.json
+++ b/packages/remark-shift-headings/package.json
@@ -1,69 +1,69 @@
 {
-  "name": "remark-shift-headings",
-  "version": "0.1.1",
-  "description": "Remark plugin to shift heading levels based on rendering context",
-  "homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/remark-shift-headings#remark-shift-headings",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/remark-shift-headings"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./esm/index.d.ts",
-        "default": "./esm/index.js"
-      }
-    }
-  },
-  "types": "./esm/index.d.ts",
-  "files": [
-    "esm"
-  ],
-  "scripts": {
-    "build:compile": "tsc --project ./tsconfig.json",
-    "check": "pnpm check:format",
-    "check:format": "biome format .",
-    "clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
-    "format": "biome check . --linter-enabled=false --write",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint . --apply",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-    "test": "vitest run test",
-    "test:coverage": "vitest run test --coverage"
-  },
-  "dependencies": {
-    "unified": "^11.0.5",
-    "unist-util-visit": "^5.1.0",
-    "vfile": "^6.0.3"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@types/mdast": "^4.0.4",
-    "@types/node": "^20.19.25",
-    "@vitest/coverage-v8": "^4.0.18",
-    "remark": "^15.0.1",
-    "remark-parse": "^11.0.0",
-    "rimraf": "^6.1.2",
-    "typescript": "~5.9.3",
-    "vitest": "^4.0.18"
-  },
-  "peerDependencies": {
-    "unified": "^11.0.5"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "nx:noop"
-      },
-      "ci": {}
-    }
-  }
+	"name": "remark-shift-headings",
+	"version": "0.1.1",
+	"description": "Remark plugin to shift heading levels based on rendering context",
+	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/remark-shift-headings#remark-shift-headings",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/remark-shift-headings"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./esm/index.d.ts",
+				"default": "./esm/index.js"
+			}
+		}
+	},
+	"types": "./esm/index.d.ts",
+	"files": [
+		"esm"
+	],
+	"scripts": {
+		"build:compile": "tsc --project ./tsconfig.json",
+		"check": "pnpm check:format",
+		"check:format": "biome format .",
+		"clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --apply",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"test": "vitest run test",
+		"test:coverage": "vitest run test --coverage"
+	},
+	"dependencies": {
+		"unified": "^11.0.5",
+		"unist-util-visit": "^5.1.0",
+		"vfile": "^6.0.3"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@types/mdast": "^4.0.4",
+		"@types/node": "^20.19.25",
+		"@vitest/coverage-v8": "^4.0.18",
+		"remark": "^15.0.1",
+		"remark-parse": "^11.0.0",
+		"rimraf": "^6.1.2",
+		"typescript": "~5.9.3",
+		"vitest": "^4.0.18"
+	},
+	"peerDependencies": {
+		"unified": "^11.0.5"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"nx": {
+		"targets": {
+			"build": {
+				"executor": "nx:noop"
+			},
+			"ci": {}
+		}
+	}
 }

--- a/packages/remark-task-table/package.json
+++ b/packages/remark-task-table/package.json
@@ -1,74 +1,74 @@
 {
-  "name": "remark-task-table",
-  "version": "0.2.0",
-  "description": "Remark plugin to generate and update task tables from package.json scripts and justfile recipes",
-  "homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/remark-task-table#remark-task-table",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/remark-task-table"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./esm/index.d.ts",
-        "default": "./esm/index.js"
-      }
-    }
-  },
-  "types": "./esm/index.d.ts",
-  "files": [
-    "esm"
-  ],
-  "scripts": {
-    "build:compile": "tsc --project ./tsconfig.json",
-    "check": "pnpm check:format",
-    "check:format": "biome format .",
-    "clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
-    "format": "biome check . --linter-enabled=false --write",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint . --apply",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-    "test": "vitest run test",
-    "test:coverage": "vitest run test --coverage"
-  },
-  "dependencies": {
-    "mdast-util-to-string": "^4.0.0",
-    "micromatch": "^4.0.8",
-    "pathe": "^2.0.3",
-    "unified": "^11.0.5",
-    "unist-util-visit": "^5.1.0",
-    "vfile": "^6.0.3"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@types/mdast": "^4.0.4",
-    "@types/micromatch": "^4.0.10",
-    "@types/node": "^20.19.25",
-    "@vitest/coverage-v8": "^4.0.18",
-    "remark": "^15.0.1",
-    "remark-gfm": "^4.0.1",
-    "remark-parse": "^11.0.0",
-    "rimraf": "^6.1.2",
-    "typescript": "~5.9.3",
-    "vitest": "^4.0.18"
-  },
-  "peerDependencies": {
-    "unified": "^11.0.5"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "nx:noop"
-      },
-      "ci": {}
-    }
-  }
+	"name": "remark-task-table",
+	"version": "0.2.0",
+	"description": "Remark plugin to generate and update task tables from package.json scripts and justfile recipes",
+	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/remark-task-table#remark-task-table",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/remark-task-table"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./esm/index.d.ts",
+				"default": "./esm/index.js"
+			}
+		}
+	},
+	"types": "./esm/index.d.ts",
+	"files": [
+		"esm"
+	],
+	"scripts": {
+		"build:compile": "tsc --project ./tsconfig.json",
+		"check": "pnpm check:format",
+		"check:format": "biome format .",
+		"clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --apply",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"test": "vitest run test",
+		"test:coverage": "vitest run test --coverage"
+	},
+	"dependencies": {
+		"mdast-util-to-string": "^4.0.0",
+		"micromatch": "^4.0.8",
+		"pathe": "^2.0.3",
+		"unified": "^11.0.5",
+		"unist-util-visit": "^5.1.0",
+		"vfile": "^6.0.3"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@types/mdast": "^4.0.4",
+		"@types/micromatch": "^4.0.10",
+		"@types/node": "^20.19.25",
+		"@vitest/coverage-v8": "^4.0.18",
+		"remark": "^15.0.1",
+		"remark-gfm": "^4.0.1",
+		"remark-parse": "^11.0.0",
+		"rimraf": "^6.1.2",
+		"typescript": "~5.9.3",
+		"vitest": "^4.0.18"
+	},
+	"peerDependencies": {
+		"unified": "^11.0.5"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"nx": {
+		"targets": {
+			"build": {
+				"executor": "nx:noop"
+			},
+			"ci": {}
+		}
+	}
 }

--- a/packages/repopo-docs/package.json
+++ b/packages/repopo-docs/package.json
@@ -1,55 +1,55 @@
 {
-  "name": "repopo-docs",
-  "version": "0.0.1",
-  "private": true,
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/repopo-docs"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "scripts": {
-    "astro": "astro",
-    "b": "nx build",
-    "build:site": "astro build",
-    "check:astro": "astro check",
-    "clean": "rimraf dist *.tsbuildinfo *.done.build.log .astro .netlify",
-    "dev": "astro dev",
-    "preview": "astro preview",
-    "start": "astro dev"
-  },
-  "dependencies": {
-    "@astrojs/check": "^0.9.6",
-    "@astrojs/netlify": "^6.6.3",
-    "@astrojs/starlight": "^0.37.0",
-    "@fontsource/ibm-plex-serif": "^5.2.7",
-    "@fontsource/metropolis": "^5.2.5",
-    "@fontsource/open-sans": "^5.2.7",
-    "astro": "^5.17.1",
-    "repopo": "workspace:^",
-    "sharp": "^0.34.5",
-    "starlight-heading-badges": "^0.6.1",
-    "starlight-links-validator": "^0.19.1",
-    "starlight-package-managers": "^0.12.0",
-    "starlight-typedoc": "^0.21.4",
-    "typedoc": "^0.28.15",
-    "typedoc-plugin-frontmatter": "^1.3.1",
-    "typedoc-plugin-markdown": "^4.9.0",
-    "typedoc-plugin-mdn-links": "^5.1.0",
-    "typescript": "~5.9.3",
-    "zod": "^4.3.5"
-  },
-  "devDependencies": {
-    "@fec/remark-a11y-emoji": "^4.0.2",
-    "@hashicorp/platform-remark-plugins": "^0.2.1"
-  },
-  "nx": {
-    "targets": {
-      "build": {},
-      "ci": {}
-    }
-  }
+	"name": "repopo-docs",
+	"version": "0.0.1",
+	"private": true,
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/repopo-docs"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"scripts": {
+		"astro": "astro",
+		"b": "nx build",
+		"build:site": "astro build",
+		"check:astro": "astro check",
+		"clean": "rimraf dist *.tsbuildinfo *.done.build.log .astro .netlify",
+		"dev": "astro dev",
+		"preview": "astro preview",
+		"start": "astro dev"
+	},
+	"dependencies": {
+		"@astrojs/check": "^0.9.6",
+		"@astrojs/netlify": "^6.6.3",
+		"@astrojs/starlight": "^0.37.0",
+		"@fontsource/ibm-plex-serif": "^5.2.7",
+		"@fontsource/metropolis": "^5.2.5",
+		"@fontsource/open-sans": "^5.2.7",
+		"astro": "^5.17.1",
+		"repopo": "workspace:^",
+		"sharp": "^0.34.5",
+		"starlight-heading-badges": "^0.6.1",
+		"starlight-links-validator": "^0.19.1",
+		"starlight-package-managers": "^0.12.0",
+		"starlight-typedoc": "^0.21.4",
+		"typedoc": "^0.28.15",
+		"typedoc-plugin-frontmatter": "^1.3.1",
+		"typedoc-plugin-markdown": "^4.9.0",
+		"typedoc-plugin-mdn-links": "^5.1.0",
+		"typescript": "~5.9.3",
+		"zod": "^4.3.5"
+	},
+	"devDependencies": {
+		"@fec/remark-a11y-emoji": "^4.0.2",
+		"@hashicorp/platform-remark-plugins": "^0.2.1"
+	},
+	"nx": {
+		"targets": {
+			"build": {},
+			"ci": {}
+		}
+	}
 }

--- a/packages/repopo/package.json
+++ b/packages/repopo/package.json
@@ -1,143 +1,143 @@
 {
-  "name": "repopo",
-  "version": "0.10.0",
-  "description": "Enforce policies on all or some of the files in a git repository.",
-  "keywords": [
-    "policy",
-    "ci"
-  ],
-  "homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/repopo#repopo---police-the-files-in-your-git-repo-with-extensible-policies",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/repopo"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "types": "./esm/index.d.ts",
-      "import": "./esm/index.js"
-    },
-    "./api": {
-      "types": "./esm/api.d.ts",
-      "import": "./esm/api.js"
-    },
-    "./policies": {
-      "types": "./esm/policies.d.ts",
-      "import": "./esm/policies.js"
-    }
-  },
-  "types": "esm/index.d.ts",
-  "bin": {
-    "repopo": "./bin/run.js"
-  },
-  "files": [
-    "/CHANGELOG.md",
-    "/bin",
-    "/oclif.manifest.json",
-    "/esm",
-    "/THIRD-PARTY-LICENSES.txt"
-  ],
-  "scripts": {
-    "api:markdown": "api-documenter markdown -i _temp/api-extractor -o _temp/docs",
-    "build:api": "api-extractor run --local",
-    "build:compile": "tsc --project ./tsconfig.json",
-    "build:manifest": "oclif manifest",
-    "build:readme": "concurrently npm:readme:*",
-    "check": "concurrently npm:check:format",
-    "check:format": "biome check . --linter-enabled=false",
-    "clean": "concurrently npm:clean:build npm:clean:manifest",
-    "clean:build": "rimraf esm *.tsbuildinfo *.done.build.log",
-    "clean:manifest": "rimraf oclif.manifest.json",
-    "format": "biome check . --linter-enabled=false --write",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint . --write",
-    "postpack": "pnpm clean:manifest",
-    "readme:docs": "oclif readme --no-aliases --readme-path=../repopo-docs/src/content/docs/cli-reference.md",
-    "readme:main": "oclif readme --no-aliases",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-    "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
-    "test:snapshots": "./bin/dev.js snapshot:compare --filepath test/commands/__snapshots__/commands.json",
-    "test:watch": "vitest"
-  },
-  "oclif": {
-    "additionalHelpFlags": [
-      "-h"
-    ],
-    "additionalVersionFlags": [
-      "-V"
-    ],
-    "bin": "repopo",
-    "commands": {
-      "strategy": "pattern",
-      "target": "./esm/commands"
-    },
-    "devPlugins": [
-      "@oclif/plugin-command-snapshot"
-    ],
-    "dirname": "repopo",
-    "plugins": [],
-    "repositoryPrefix": "<%- repo %>/blob/main/packages/repopo/<%- commandPath %>"
-  },
-  "dependencies": {
-    "@fluid-tools/build-infrastructure": "~0.63.0",
-    "@oclif/core": "^4.8.0",
-    "@oclif/plugin-help": "^6.2.36",
-    "@rushstack/node-core-library": "^5.19.0",
-    "@tylerbu/cli-api": "workspace:^",
-    "@tylerbu/fundamentals": "workspace:^",
-    "consola": "^3.4.0",
-    "defu": "^6.1.4",
-    "effection": "^4.0.0",
-    "jsonfile": "^6.2.0",
-    "microdiff": "^1.5.0",
-    "pathe": "^2.0.3",
-    "picocolors": "^1.1.1",
-    "picomatch": "^4.0.3",
-    "resolve-workspace-root": "^2.0.0",
-    "simple-git": "^3.30.0",
-    "tinyglobby": "^0.2.15"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@microsoft/api-extractor": "^7.56.0",
-    "@oclif/plugin-command-snapshot": "^5.3.8",
-    "@oclif/test": "^4.1.15",
-    "@types/jsonfile": "^6.1.4",
-    "@types/node": "^20.19.25",
-    "@types/picomatch": "^4.0.2",
-    "@types/tmp": "^0.2.6",
-    "@vitest/coverage-v8": "^4.0.18",
-    "generate-license-file": "^4.1.1",
-    "oclif": "^4.22.50",
-    "rimraf": "^6.1.2",
-    "tmp-promise": "^3.0.3",
-    "ts-node": "^10.9.2",
-    "type-fest": "^5.4.1",
-    "typescript": "~5.9.3",
-    "vitest": "^4.0.18"
-  },
-  "peerDependencies": {
-    "sort-package-json": "*"
-  },
-  "peerDependenciesMeta": {
-    "sort-package-json": {
-      "optional": true
-    }
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "nx:noop"
-      },
-      "ci": {}
-    }
-  }
+	"name": "repopo",
+	"version": "0.10.0",
+	"description": "Enforce policies on all or some of the files in a git repository.",
+	"keywords": [
+		"policy",
+		"ci"
+	],
+	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/repopo#repopo---police-the-files-in-your-git-repo-with-extensible-policies",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/repopo"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./esm/index.d.ts",
+			"import": "./esm/index.js"
+		},
+		"./api": {
+			"types": "./esm/api.d.ts",
+			"import": "./esm/api.js"
+		},
+		"./policies": {
+			"types": "./esm/policies.d.ts",
+			"import": "./esm/policies.js"
+		}
+	},
+	"types": "esm/index.d.ts",
+	"bin": {
+		"repopo": "./bin/run.js"
+	},
+	"files": [
+		"/CHANGELOG.md",
+		"/bin",
+		"/oclif.manifest.json",
+		"/esm",
+		"/THIRD-PARTY-LICENSES.txt"
+	],
+	"scripts": {
+		"api:markdown": "api-documenter markdown -i _temp/api-extractor -o _temp/docs",
+		"build:api": "api-extractor run --local",
+		"build:compile": "tsc --project ./tsconfig.json",
+		"build:manifest": "oclif manifest",
+		"build:readme": "concurrently npm:readme:*",
+		"check": "concurrently npm:check:format",
+		"check:format": "biome check . --linter-enabled=false",
+		"clean": "concurrently npm:clean:build npm:clean:manifest",
+		"clean:build": "rimraf esm *.tsbuildinfo *.done.build.log",
+		"clean:manifest": "rimraf oclif.manifest.json",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --write",
+		"postpack": "pnpm clean:manifest",
+		"readme:docs": "oclif readme --no-aliases --readme-path=../repopo-docs/src/content/docs/cli-reference.md",
+		"readme:main": "oclif readme --no-aliases",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage",
+		"test:snapshots": "./bin/dev.js snapshot:compare --filepath test/commands/__snapshots__/commands.json",
+		"test:watch": "vitest"
+	},
+	"oclif": {
+		"additionalHelpFlags": [
+			"-h"
+		],
+		"additionalVersionFlags": [
+			"-V"
+		],
+		"bin": "repopo",
+		"commands": {
+			"strategy": "pattern",
+			"target": "./esm/commands"
+		},
+		"devPlugins": [
+			"@oclif/plugin-command-snapshot"
+		],
+		"dirname": "repopo",
+		"plugins": [],
+		"repositoryPrefix": "<%- repo %>/blob/main/packages/repopo/<%- commandPath %>"
+	},
+	"dependencies": {
+		"@fluid-tools/build-infrastructure": "~0.63.0",
+		"@oclif/core": "^4.8.0",
+		"@oclif/plugin-help": "^6.2.36",
+		"@rushstack/node-core-library": "^5.19.0",
+		"@tylerbu/cli-api": "workspace:^",
+		"@tylerbu/fundamentals": "workspace:^",
+		"consola": "^3.4.0",
+		"defu": "^6.1.4",
+		"effection": "^4.0.0",
+		"jsonfile": "^6.2.0",
+		"microdiff": "^1.5.0",
+		"pathe": "^2.0.3",
+		"picocolors": "^1.1.1",
+		"picomatch": "^4.0.3",
+		"resolve-workspace-root": "^2.0.0",
+		"simple-git": "^3.30.0",
+		"tinyglobby": "^0.2.15"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@microsoft/api-extractor": "^7.56.0",
+		"@oclif/plugin-command-snapshot": "^5.3.8",
+		"@oclif/test": "^4.1.15",
+		"@types/jsonfile": "^6.1.4",
+		"@types/node": "^20.19.25",
+		"@types/picomatch": "^4.0.2",
+		"@types/tmp": "^0.2.6",
+		"@vitest/coverage-v8": "^4.0.18",
+		"generate-license-file": "^4.1.1",
+		"oclif": "^4.22.50",
+		"rimraf": "^6.1.2",
+		"tmp-promise": "^3.0.3",
+		"ts-node": "^10.9.2",
+		"type-fest": "^5.4.1",
+		"typescript": "~5.9.3",
+		"vitest": "^4.0.18"
+	},
+	"peerDependencies": {
+		"sort-package-json": "*"
+	},
+	"peerDependenciesMeta": {
+		"sort-package-json": {
+			"optional": true
+		}
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"nx": {
+		"targets": {
+			"build": {
+				"executor": "nx:noop"
+			},
+			"ci": {}
+		}
+	}
 }

--- a/packages/sail-infrastructure/package.json
+++ b/packages/sail-infrastructure/package.json
@@ -1,91 +1,91 @@
 {
-  "name": "@tylerbu/sail-infrastructure",
-  "version": "0.4.0",
-  "description": "Sail build infrastructure",
-  "homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/sail-infrastructure#tylerbusail-infrastructure",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/sail-infrastructure"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./esm/index.d.ts",
-        "default": "./esm/index.js"
-      }
-    }
-  },
-  "types": "./esm/index.d.ts",
-  "files": [
-    "/esm",
-    "!esm/test"
-  ],
-  "scripts": {
-    "build:compile": "tsc --project ./tsconfig.json",
-    "build:docs": "typedoc",
-    "check": "pnpm check:format",
-    "check:format": "biome check . --linter-enabled=false",
-    "clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log .coverage",
-    "format": "biome check . --linter-enabled=false --write",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint . --write",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-    "test": "vitest run test",
-    "test:coverage": "vitest run test --coverage"
-  },
-  "dependencies": {
-    "@manypkg/get-packages": "^3.1.0",
-    "@oclif/core": "^4.8.0",
-    "@tylerbu/fundamentals": "workspace:^",
-    "@tylerbu/lilconfig-loader-ts": "workspace:^",
-    "detect-indent": "^7.0.2",
-    "fs-extra": "^11.3.2",
-    "lilconfig": "^3.1.3",
-    "micromatch": "^4.0.8",
-    "oclif": "^4.22.50",
-    "package-manager-detector": "^0.2.11",
-    "pathe": "^2.0.3",
-    "picocolors": "^1.1.1",
-    "read-pkg-up": "^11.0.0",
-    "resolve-workspace-root": "^2.0.0",
-    "semver": "^7.7.3",
-    "simple-git": "^3.30.0",
-    "sort-package-json": "*",
-    "tinyexec": "^1.0.2",
-    "tinyglobby": "^0.2.15",
-    "type-fest": "^5.4.1",
-    "typescript": "~5.9.3"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@microsoft/api-extractor": "^7.56.0",
-    "@oclif/test": "^4.1.15",
-    "@types/fs-extra": "^11.0.4",
-    "@types/micromatch": "^4.0.10",
-    "@types/node": "^20.19.25",
-    "@types/semver": "^7.7.1",
-    "@vitest/coverage-v8": "^4.0.18",
-    "concurrently": "^9.2.1",
-    "rimraf": "^6.1.2",
-    "ts-node": "^10.9.2",
-    "typedoc": "^0.28.15",
-    "typedoc-plugin-markdown": "^4.9.0",
-    "vitest": "^4.0.18"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "nx:noop"
-      },
-      "ci": {}
-    }
-  }
+	"name": "@tylerbu/sail-infrastructure",
+	"version": "0.4.0",
+	"description": "Sail build infrastructure",
+	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/sail-infrastructure#tylerbusail-infrastructure",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/sail-infrastructure"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./esm/index.d.ts",
+				"default": "./esm/index.js"
+			}
+		}
+	},
+	"types": "./esm/index.d.ts",
+	"files": [
+		"/esm",
+		"!esm/test"
+	],
+	"scripts": {
+		"build:compile": "tsc --project ./tsconfig.json",
+		"build:docs": "typedoc",
+		"check": "pnpm check:format",
+		"check:format": "biome check . --linter-enabled=false",
+		"clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log .coverage",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --write",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"test": "vitest run test",
+		"test:coverage": "vitest run test --coverage"
+	},
+	"dependencies": {
+		"@manypkg/get-packages": "^3.1.0",
+		"@oclif/core": "^4.8.0",
+		"@tylerbu/fundamentals": "workspace:^",
+		"@tylerbu/lilconfig-loader-ts": "workspace:^",
+		"detect-indent": "^7.0.2",
+		"fs-extra": "^11.3.2",
+		"lilconfig": "^3.1.3",
+		"micromatch": "^4.0.8",
+		"oclif": "^4.22.50",
+		"package-manager-detector": "^0.2.11",
+		"pathe": "^2.0.3",
+		"picocolors": "^1.1.1",
+		"read-pkg-up": "^11.0.0",
+		"resolve-workspace-root": "^2.0.0",
+		"semver": "^7.7.3",
+		"simple-git": "^3.30.0",
+		"sort-package-json": "*",
+		"tinyexec": "^1.0.2",
+		"tinyglobby": "^0.2.15",
+		"type-fest": "^5.4.1",
+		"typescript": "~5.9.3"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@microsoft/api-extractor": "^7.56.0",
+		"@oclif/test": "^4.1.15",
+		"@types/fs-extra": "^11.0.4",
+		"@types/micromatch": "^4.0.10",
+		"@types/node": "^20.19.25",
+		"@types/semver": "^7.7.1",
+		"@vitest/coverage-v8": "^4.0.18",
+		"concurrently": "^9.2.1",
+		"rimraf": "^6.1.2",
+		"ts-node": "^10.9.2",
+		"typedoc": "^0.28.15",
+		"typedoc-plugin-markdown": "^4.9.0",
+		"vitest": "^4.0.18"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"nx": {
+		"targets": {
+			"build": {
+				"executor": "nx:noop"
+			},
+			"ci": {}
+		}
+	}
 }

--- a/packages/sail/package.json
+++ b/packages/sail/package.json
@@ -1,175 +1,175 @@
 {
-  "name": "@tylerbu/sail",
-  "version": "0.2.3",
-  "description": "Build orchestration CLI tool",
-  "keywords": [
-    "oclif",
-    "build",
-    "monorepo"
-  ],
-  "homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/sail#tylerbusail",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/sail"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./esm/index.d.ts",
-        "default": "./esm/index.js"
-      }
-    }
-  },
-  "types": "esm/index.d.ts",
-  "bin": {
-    "sail": "./bin/run.js"
-  },
-  "files": [
-    "/bin",
-    "/CHANGELOG.md",
-    "/esm",
-    "/oclif.manifest.json",
-    "/THIRD-PARTY-LICENSES.txt"
-  ],
-  "scripts": {
-    "build:api": "api-extractor run --local",
-    "build:compile": "tsc --project ./tsconfig.json",
-    "build:generate": "./bin/dev.js snapshot:generate --filepath test/commands/__snapshots__/commands.json",
-    "build:manifest": "oclif manifest",
-    "build:readme": "oclif readme --multi --no-aliases",
-    "check": "pnpm check:format",
-    "check:format": "biome check . --linter-enabled=false",
-    "clean": "concurrently npm:clean:build npm:clean:manifest",
-    "clean:build": "rimraf esm _temp *.tsbuildinfo *.done.build.log .coverage",
-    "clean:manifest": "rimraf oclif.manifest.json",
-    "format": "biome check . --linter-enabled=false --write",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint . --write",
-    "postpack": "pnpm clean:manifest",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-    "start": "serve ./test/data --listen 8080",
-    "test": "vitest run test",
-    "test:coverage": "vitest run test --coverage",
-    "test:integration": "vitest run test/integration",
-    "test:snapshots": "./bin/dev.js snapshot:compare --filepath test/commands/__snapshots__/commands.json",
-    "test:unit": "vitest run test/unit"
-  },
-  "oclif": {
-    "additionalHelpFlags": [
-      "-h"
-    ],
-    "additionalVersionFlags": [
-      "-V"
-    ],
-    "bin": "sail",
-    "commands": "./esm/commands",
-    "devPlugins": [
-      "@oclif/plugin-command-snapshot"
-    ],
-    "dirname": "sail",
-    "flexibleTaxonomy": true,
-    "helpOptions": {
-      "hideAliasesFromRoot": true,
-      "hideCommandSummaryInDescription": true,
-      "showFlagNameInTitle": false,
-      "showFlagOptionsInTitle": true,
-      "stripAnsi": true
-    },
-    "plugins": [
-      "@oclif/plugin-autocomplete",
-      "@oclif/plugin-commands",
-      "@oclif/plugin-help",
-      "@oclif/plugin-not-found",
-      "@oclif/plugin-version",
-      "@oclif/plugin-warn-if-update-available"
-    ],
-    "repositoryPrefix": "<%- repo %>/blob/main/packages/sail/<%- commandPath %>",
-    "topicSeparator": " ",
-    "topics": {
-      "cache": {
-        "description": "Cache management commands for build artifacts and file hashes."
-      }
-    }
-  },
-  "dependencies": {
-    "@manypkg/get-packages": "^3.1.0",
-    "@oclif/core": "^4.8.0",
-    "@oclif/plugin-autocomplete": "^3.2.39",
-    "@oclif/plugin-commands": "^4.1.38",
-    "@oclif/plugin-help": "^6.2.36",
-    "@oclif/plugin-not-found": "^3.2.73",
-    "@oclif/plugin-version": "^2.2.36",
-    "@oclif/plugin-warn-if-update-available": "^3.1.53",
-    "@tylerbu/cli-api": "workspace:^",
-    "@tylerbu/lilconfig-loader-ts": "workspace:^",
-    "@tylerbu/sail-infrastructure": "workspace:^",
-    "async": "^3.2.6",
-    "date-fns": "^4.1.0",
-    "debug": "^4.4.3",
-    "detect-indent": "^7.0.2",
-    "find-up": "^8.0.0",
-    "fs-extra": "^11.3.2",
-    "glob": "^7.2.3",
-    "globby": "^11.1.0",
-    "ignore": "^7.0.5",
-    "json5": "^2.2.3",
-    "lilconfig": "^3.1.3",
-    "lodash": "^4.17.21",
-    "lodash.isequal": "^4.5.0",
-    "log-update": "^7.1.0",
-    "multimatch": "^7.0.0",
-    "picocolors": "^1.1.1",
-    "picomatch": "^4.0.3",
-    "picospinner": "^3.0.0",
-    "rimraf": "^6.1.2",
-    "semver": "^7.7.3",
-    "simple-git": "^3.30.0",
-    "sort-package-json": "2.14.0",
-    "std-env": "^3.10.0",
-    "ts-deepmerge": "^7.0.3",
-    "ts-morph": "^27.0.2",
-    "type-fest": "^5.4.1",
-    "typescript": "~5.9.3",
-    "uncrypto": "^0.1.3",
-    "yaml": "^2.8.1"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@microsoft/api-extractor": "^7.56.0",
-    "@oclif/plugin-command-snapshot": "^5.3.8",
-    "@oclif/test": "^4.1.15",
-    "@types/async": "^3.2.25",
-    "@types/debug": "^4.1.12",
-    "@types/fs-extra": "^11.0.4",
-    "@types/glob": "^8.1.0",
-    "@types/jsonfile": "^6.1.4",
-    "@types/lodash.isequal": "^4.5.8",
-    "@types/node": "^20.19.25",
-    "@types/picomatch": "^4.0.2",
-    "@types/semver": "^7.7.1",
-    "@vitest/coverage-v8": "^4.0.18",
-    "concurrently": "^9.2.1",
-    "generate-license-file": "^4.1.1",
-    "oclif": "^4.22.50",
-    "pathe": "^2.0.3",
-    "rimraf": "^6.1.2",
-    "ts-node": "^10.9.2",
-    "vitest": "^4.0.18"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "nx": {
-    "targets": {
-      "build": {
-        "executor": "nx:noop"
-      },
-      "ci": {}
-    }
-  }
+	"name": "@tylerbu/sail",
+	"version": "0.2.3",
+	"description": "Build orchestration CLI tool",
+	"keywords": [
+		"oclif",
+		"build",
+		"monorepo"
+	],
+	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/sail#tylerbusail",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/sail"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./esm/index.d.ts",
+				"default": "./esm/index.js"
+			}
+		}
+	},
+	"types": "esm/index.d.ts",
+	"bin": {
+		"sail": "./bin/run.js"
+	},
+	"files": [
+		"/bin",
+		"/CHANGELOG.md",
+		"/esm",
+		"/oclif.manifest.json",
+		"/THIRD-PARTY-LICENSES.txt"
+	],
+	"scripts": {
+		"build:api": "api-extractor run --local",
+		"build:compile": "tsc --project ./tsconfig.json",
+		"build:generate": "./bin/dev.js snapshot:generate --filepath test/commands/__snapshots__/commands.json",
+		"build:manifest": "oclif manifest",
+		"build:readme": "oclif readme --multi --no-aliases",
+		"check": "pnpm check:format",
+		"check:format": "biome check . --linter-enabled=false",
+		"clean": "concurrently npm:clean:build npm:clean:manifest",
+		"clean:build": "rimraf esm _temp *.tsbuildinfo *.done.build.log .coverage",
+		"clean:manifest": "rimraf oclif.manifest.json",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --write",
+		"postpack": "pnpm clean:manifest",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"start": "serve ./test/data --listen 8080",
+		"test": "vitest run test",
+		"test:coverage": "vitest run test --coverage",
+		"test:integration": "vitest run test/integration",
+		"test:snapshots": "./bin/dev.js snapshot:compare --filepath test/commands/__snapshots__/commands.json",
+		"test:unit": "vitest run test/unit"
+	},
+	"oclif": {
+		"additionalHelpFlags": [
+			"-h"
+		],
+		"additionalVersionFlags": [
+			"-V"
+		],
+		"bin": "sail",
+		"commands": "./esm/commands",
+		"devPlugins": [
+			"@oclif/plugin-command-snapshot"
+		],
+		"dirname": "sail",
+		"flexibleTaxonomy": true,
+		"helpOptions": {
+			"hideAliasesFromRoot": true,
+			"hideCommandSummaryInDescription": true,
+			"showFlagNameInTitle": false,
+			"showFlagOptionsInTitle": true,
+			"stripAnsi": true
+		},
+		"plugins": [
+			"@oclif/plugin-autocomplete",
+			"@oclif/plugin-commands",
+			"@oclif/plugin-help",
+			"@oclif/plugin-not-found",
+			"@oclif/plugin-version",
+			"@oclif/plugin-warn-if-update-available"
+		],
+		"repositoryPrefix": "<%- repo %>/blob/main/packages/sail/<%- commandPath %>",
+		"topicSeparator": " ",
+		"topics": {
+			"cache": {
+				"description": "Cache management commands for build artifacts and file hashes."
+			}
+		}
+	},
+	"dependencies": {
+		"@manypkg/get-packages": "^3.1.0",
+		"@oclif/core": "^4.8.0",
+		"@oclif/plugin-autocomplete": "^3.2.39",
+		"@oclif/plugin-commands": "^4.1.38",
+		"@oclif/plugin-help": "^6.2.36",
+		"@oclif/plugin-not-found": "^3.2.73",
+		"@oclif/plugin-version": "^2.2.36",
+		"@oclif/plugin-warn-if-update-available": "^3.1.53",
+		"@tylerbu/cli-api": "workspace:^",
+		"@tylerbu/lilconfig-loader-ts": "workspace:^",
+		"@tylerbu/sail-infrastructure": "workspace:^",
+		"async": "^3.2.6",
+		"date-fns": "^4.1.0",
+		"debug": "^4.4.3",
+		"detect-indent": "^7.0.2",
+		"find-up": "^8.0.0",
+		"fs-extra": "^11.3.2",
+		"glob": "^7.2.3",
+		"globby": "^11.1.0",
+		"ignore": "^7.0.5",
+		"json5": "^2.2.3",
+		"lilconfig": "^3.1.3",
+		"lodash": "^4.17.21",
+		"lodash.isequal": "^4.5.0",
+		"log-update": "^7.1.0",
+		"multimatch": "^7.0.0",
+		"picocolors": "^1.1.1",
+		"picomatch": "^4.0.3",
+		"picospinner": "^3.0.0",
+		"rimraf": "^6.1.2",
+		"semver": "^7.7.3",
+		"simple-git": "^3.30.0",
+		"sort-package-json": "2.14.0",
+		"std-env": "^3.10.0",
+		"ts-deepmerge": "^7.0.3",
+		"ts-morph": "^27.0.2",
+		"type-fest": "^5.4.1",
+		"typescript": "~5.9.3",
+		"uncrypto": "^0.1.3",
+		"yaml": "^2.8.1"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@microsoft/api-extractor": "^7.56.0",
+		"@oclif/plugin-command-snapshot": "^5.3.8",
+		"@oclif/test": "^4.1.15",
+		"@types/async": "^3.2.25",
+		"@types/debug": "^4.1.12",
+		"@types/fs-extra": "^11.0.4",
+		"@types/glob": "^8.1.0",
+		"@types/jsonfile": "^6.1.4",
+		"@types/lodash.isequal": "^4.5.8",
+		"@types/node": "^20.19.25",
+		"@types/picomatch": "^4.0.2",
+		"@types/semver": "^7.7.1",
+		"@vitest/coverage-v8": "^4.0.18",
+		"concurrently": "^9.2.1",
+		"generate-license-file": "^4.1.1",
+		"oclif": "^4.22.50",
+		"pathe": "^2.0.3",
+		"rimraf": "^6.1.2",
+		"ts-node": "^10.9.2",
+		"vitest": "^4.0.18"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"nx": {
+		"targets": {
+			"build": {
+				"executor": "nx:noop"
+			},
+			"ci": {}
+		}
+	}
 }

--- a/packages/sort-tsconfig/package.json
+++ b/packages/sort-tsconfig/package.json
@@ -1,127 +1,127 @@
 {
-  "name": "sort-tsconfig",
-  "version": "0.4.0",
-  "description": "Sorts tsconfig files.",
-  "keywords": [
-    "sort",
-    "tsconfig",
-    "typescript"
-  ],
-  "homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/sort-tsconfig#sort-tsconfig---keep-your-tsconfigs-clean-and-tidy",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/sort-tsconfig"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "types": "./esm/index.d.ts",
-      "import": "./esm/index.js"
-    },
-    "./command": {
-      "types": "./esm/commands/sort-tsconfig.d.ts",
-      "import": "./esm/commands/sort-tsconfig.js"
-    }
-  },
-  "types": "esm/index.d.ts",
-  "bin": {
-    "sort-tsconfig": "./bin/run.js"
-  },
-  "files": [
-    "/bin",
-    "/CHANGELOG.md",
-    "/esm",
-    "/oclif.manifest.json",
-    "/THIRD-PARTY-LICENSES.txt"
-  ],
-  "scripts": {
-    "b": "nx build",
-    "build:api": "api-extractor run --local",
-    "build:compile": "tsc",
-    "build:manifest": "oclif manifest",
-    "build:readme": "concurrently npm:readme:*",
-    "build:test": "tsc --project ./test/tsconfig.json",
-    "check": "concurrently npm:check:format",
-    "check:format": "biome check . --linter-enabled=false",
-    "check:snapshot": "./bin/dev.js snapshot:compare --filepath test/commands/_snapshots/commands.json",
-    "clean": "concurrently npm:clean:build npm:clean:manifest",
-    "clean:build": "rimraf esm *.tsbuildinfo *.done.build.log",
-    "clean:manifest": "rimraf oclif.manifest.json",
-    "format": "sort-package-json && biome check . --linter-enabled=false --write",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint . --write",
-    "postpack": "pnpm clean:manifest",
-    "readme:main": "oclif readme --no-aliases",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-    "start": "serve ./test/data --listen 8080",
-    "test:coverage": "vitest run test --coverage",
-    "test:snapshots": "pnpm update:test-snapshots",
-    "test:vitest": "vitest run test",
-    "update:test-snapshots": "vitest run test -u"
-  },
-  "oclif": {
-    "bin": "sort-tsconfig",
-    "commands": {
-      "strategy": "single",
-      "target": "./esm/commands/sort-tsconfig.js"
-    },
-    "default": "sort",
-    "devPlugins": [],
-    "dirname": "sort-tsconfig",
-    "plugins": [],
-    "repositoryPrefix": "<%- repo %>/blob/main/packages/sort-tsconfig/<%- commandPath %>"
-  },
-  "dependencies": {
-    "@oclif/core": "^4.8.0",
-    "@oclif/plugin-help": "^6.2.36",
-    "@tylerbu/cli-api": "workspace:^",
-    "@tylerbu/fundamentals": "workspace:^",
-    "detect-indent": "^7.0.2",
-    "pathe": "^2.0.3",
-    "sort-jsonc": "^1.0.2",
-    "tiny-jsonc": "^1.0.2",
-    "tinyglobby": "^0.2.15"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@microsoft/api-extractor": "^7.56.0",
-    "@oclif/plugin-command-snapshot": "^5.3.8",
-    "@oclif/test": "^4.1.15",
-    "@types/node": "^20.19.25",
-    "@types/tmp": "^0.2.6",
-    "@vitest/coverage-v8": "^4.0.18",
-    "generate-license-file": "^4.1.1",
-    "oclif": "^4.22.50",
-    "repopo": "workspace:^",
-    "rimraf": "^6.1.2",
-    "sort-package-json": "*",
-    "start-server-and-test": "^2.1.3",
-    "tmp-promise": "^3.0.3",
-    "tsx": "^4.21.0",
-    "type-fest": "^5.4.1",
-    "typescript": "~5.9.3",
-    "vitest": "^4.0.18"
-  },
-  "peerDependencies": {
-    "repopo": ">=0.5.0"
-  },
-  "peerDependenciesMeta": {
-    "repopo": {
-      "optional": true
-    }
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "nx": {
-    "targets": {
-      "build": {},
-      "test": {},
-      "ci": {}
-    }
-  }
+	"name": "sort-tsconfig",
+	"version": "0.4.0",
+	"description": "Sorts tsconfig files.",
+	"keywords": [
+		"sort",
+		"tsconfig",
+		"typescript"
+	],
+	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/sort-tsconfig#sort-tsconfig---keep-your-tsconfigs-clean-and-tidy",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/sort-tsconfig"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./esm/index.d.ts",
+			"import": "./esm/index.js"
+		},
+		"./command": {
+			"types": "./esm/commands/sort-tsconfig.d.ts",
+			"import": "./esm/commands/sort-tsconfig.js"
+		}
+	},
+	"types": "esm/index.d.ts",
+	"bin": {
+		"sort-tsconfig": "./bin/run.js"
+	},
+	"files": [
+		"/bin",
+		"/CHANGELOG.md",
+		"/esm",
+		"/oclif.manifest.json",
+		"/THIRD-PARTY-LICENSES.txt"
+	],
+	"scripts": {
+		"b": "nx build",
+		"build:api": "api-extractor run --local",
+		"build:compile": "tsc",
+		"build:manifest": "oclif manifest",
+		"build:readme": "concurrently npm:readme:*",
+		"build:test": "tsc --project ./test/tsconfig.json",
+		"check": "concurrently npm:check:format",
+		"check:format": "biome check . --linter-enabled=false",
+		"check:snapshot": "./bin/dev.js snapshot:compare --filepath test/commands/_snapshots/commands.json",
+		"clean": "concurrently npm:clean:build npm:clean:manifest",
+		"clean:build": "rimraf esm *.tsbuildinfo *.done.build.log",
+		"clean:manifest": "rimraf oclif.manifest.json",
+		"format": "sort-package-json && biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --write",
+		"postpack": "pnpm clean:manifest",
+		"readme:main": "oclif readme --no-aliases",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"start": "serve ./test/data --listen 8080",
+		"test:coverage": "vitest run test --coverage",
+		"test:snapshots": "pnpm update:test-snapshots",
+		"test:vitest": "vitest run test",
+		"update:test-snapshots": "vitest run test -u"
+	},
+	"oclif": {
+		"bin": "sort-tsconfig",
+		"commands": {
+			"strategy": "single",
+			"target": "./esm/commands/sort-tsconfig.js"
+		},
+		"default": "sort",
+		"devPlugins": [],
+		"dirname": "sort-tsconfig",
+		"plugins": [],
+		"repositoryPrefix": "<%- repo %>/blob/main/packages/sort-tsconfig/<%- commandPath %>"
+	},
+	"dependencies": {
+		"@oclif/core": "^4.8.0",
+		"@oclif/plugin-help": "^6.2.36",
+		"@tylerbu/cli-api": "workspace:^",
+		"@tylerbu/fundamentals": "workspace:^",
+		"detect-indent": "^7.0.2",
+		"pathe": "^2.0.3",
+		"sort-jsonc": "^1.0.2",
+		"tiny-jsonc": "^1.0.2",
+		"tinyglobby": "^0.2.15"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@microsoft/api-extractor": "^7.56.0",
+		"@oclif/plugin-command-snapshot": "^5.3.8",
+		"@oclif/test": "^4.1.15",
+		"@types/node": "^20.19.25",
+		"@types/tmp": "^0.2.6",
+		"@vitest/coverage-v8": "^4.0.18",
+		"generate-license-file": "^4.1.1",
+		"oclif": "^4.22.50",
+		"repopo": "workspace:^",
+		"rimraf": "^6.1.2",
+		"sort-package-json": "*",
+		"start-server-and-test": "^2.1.3",
+		"tmp-promise": "^3.0.3",
+		"tsx": "^4.21.0",
+		"type-fest": "^5.4.1",
+		"typescript": "~5.9.3",
+		"vitest": "^4.0.18"
+	},
+	"peerDependencies": {
+		"repopo": ">=0.5.0"
+	},
+	"peerDependenciesMeta": {
+		"repopo": {
+			"optional": true
+		}
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"nx": {
+		"targets": {
+			"build": {},
+			"test": {},
+			"ci": {}
+		}
+	}
 }

--- a/packages/xkcd2-api/package.json
+++ b/packages/xkcd2-api/package.json
@@ -1,65 +1,65 @@
 {
-  "name": "@tylerbu/xkcd2-api",
-  "version": "0.1.2",
-  "description": "TypeScript APIs used in implementations of xkcd2.com.",
-  "homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/fundamentals#tylerbufundamentals",
-  "bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tylerbutler/tools-monorepo.git",
-    "directory": "packages/xkcd2-api"
-  },
-  "license": "MIT",
-  "author": "Tyler Butler <tyler@tylerbutler.com>",
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./esm/index.d.ts",
-        "default": "./esm/index.js"
-      }
-    }
-  },
-  "types": "./esm/index.d.ts",
-  "files": [
-    "esm"
-  ],
-  "scripts": {
-    "b": "nx build",
-    "build": "pnpm build:compile",
-    "build:api": "api-extractor run --local",
-    "build:compile": "tsc --project ./tsconfig.json",
-    "build:docs": "typedoc",
-    "check": "pnpm check:format",
-    "check:format": "biome format .",
-    "clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
-    "format": "biome check . --linter-enabled=false --write",
-    "lint": "biome lint .",
-    "lint:fix": "biome lint . --apply",
-    "release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
-    "test": "vitest run test",
-    "test:coverage": "vitest run test --coverage"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "@microsoft/api-documenter": "^7.28.1",
-    "@microsoft/api-extractor": "^7.56.0",
-    "@types/node": "^20.19.25",
-    "@vitest/coverage-v8": "^4.0.18",
-    "concurrently": "^9.2.1",
-    "rimraf": "^6.1.2",
-    "sort-package-json": "*",
-    "typedoc": "^0.28.15",
-    "typedoc-plugin-markdown": "^4.9.0",
-    "typescript": "~5.9.3",
-    "vitest": "^4.0.18"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "nx": {
-    "targets": {
-      "ci": {}
-    }
-  }
+	"name": "@tylerbu/xkcd2-api",
+	"version": "0.1.2",
+	"description": "TypeScript APIs used in implementations of xkcd2.com.",
+	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/fundamentals#tylerbufundamentals",
+	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/tylerbutler/tools-monorepo.git",
+		"directory": "packages/xkcd2-api"
+	},
+	"license": "MIT",
+	"author": "Tyler Butler <tyler@tylerbutler.com>",
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./esm/index.d.ts",
+				"default": "./esm/index.js"
+			}
+		}
+	},
+	"types": "./esm/index.d.ts",
+	"files": [
+		"esm"
+	],
+	"scripts": {
+		"b": "nx build",
+		"build": "pnpm build:compile",
+		"build:api": "api-extractor run --local",
+		"build:compile": "tsc --project ./tsconfig.json",
+		"build:docs": "typedoc",
+		"check": "pnpm check:format",
+		"check:format": "biome format .",
+		"clean": "rimraf esm _temp *.tsbuildinfo *.done.build.log",
+		"format": "biome check . --linter-enabled=false --write",
+		"lint": "biome lint .",
+		"lint:fix": "biome lint . --apply",
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"test": "vitest run test",
+		"test:coverage": "vitest run test --coverage"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.8",
+		"@microsoft/api-documenter": "^7.28.1",
+		"@microsoft/api-extractor": "^7.56.0",
+		"@types/node": "^20.19.25",
+		"@vitest/coverage-v8": "^4.0.18",
+		"concurrently": "^9.2.1",
+		"rimraf": "^6.1.2",
+		"sort-package-json": "*",
+		"typedoc": "^0.28.15",
+		"typedoc-plugin-markdown": "^4.9.0",
+		"typescript": "~5.9.3",
+		"vitest": "^4.0.18"
+	},
+	"engines": {
+		"node": ">=18.0.0"
+	},
+	"nx": {
+		"targets": {
+			"ci": {}
+		}
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -608,41 +608,41 @@ importers:
   packages/levee-client:
     dependencies:
       '@fluidframework/container-definitions':
-        specifier: ~2.42.0
-        version: 2.42.0
+        specifier: ~2.33.2
+        version: 2.33.2
       '@fluidframework/container-loader':
-        specifier: ~2.42.0
-        version: 2.42.0
+        specifier: ~2.33.2
+        version: 2.33.2
       '@fluidframework/core-interfaces':
-        specifier: ~2.42.0
-        version: 2.42.0
+        specifier: ~2.33.2
+        version: 2.33.2
       '@fluidframework/core-utils':
-        specifier: ~2.42.0
-        version: 2.42.0
+        specifier: ~2.33.2
+        version: 2.33.2
       '@fluidframework/driver-definitions':
-        specifier: ~2.42.0
-        version: 2.42.0
+        specifier: ~2.33.2
+        version: 2.33.2
       '@fluidframework/driver-utils':
-        specifier: ~2.42.0
-        version: 2.42.0(debug@4.4.3)
+        specifier: ~2.33.2
+        version: 2.33.2(debug@4.4.3)
       '@fluidframework/fluid-static':
-        specifier: ~2.42.0
-        version: 2.42.0
+        specifier: ~2.33.2
+        version: 2.33.2
       '@fluidframework/map':
-        specifier: ~2.42.0
-        version: 2.42.0(debug@4.4.3)
+        specifier: ~2.33.2
+        version: 2.33.2
       '@fluidframework/routerlicious-driver':
-        specifier: ~2.42.0
-        version: 2.42.0(debug@4.4.3)(encoding@0.1.13)
+        specifier: ~2.33.2
+        version: 2.33.2(encoding@0.1.13)
       '@fluidframework/runtime-utils':
-        specifier: ~2.42.0
-        version: 2.42.0(debug@4.4.3)
+        specifier: ~2.33.2
+        version: 2.33.2
       '@fluidframework/telemetry-utils':
-        specifier: ~2.42.0
-        version: 2.42.0
+        specifier: ~2.33.2
+        version: 2.33.2
       '@fluidframework/tinylicious-driver':
-        specifier: ~2.42.0
-        version: 2.42.0(encoding@0.1.13)
+        specifier: ~2.33.2
+        version: 2.33.2(encoding@0.1.13)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.2
@@ -678,7 +678,7 @@ importers:
         specifier: ^20.19.25
         version: 20.19.25
       '@vitest/coverage-v8':
-        specifier: ^4.0.18
+        specifier: ^4.0.17
         version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
       concurrently:
         specifier: ^9.2.1
@@ -705,7 +705,7 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
       vitest:
-        specifier: ^4.0.18
+        specifier: ^4.0.17
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/lilconfig-loader-ts:
@@ -3037,6 +3037,9 @@ packages:
     resolution: {integrity: sha512-Au3jSkt66PRwTKTCYm7KzTGfMzUmn1LYPK+cyrytfzjfOPkHpohrLcGYPLsgxV8nzc4vXxt3Ay7MlBrmeIfFLg==}
     engines: {node: '>=16.0'}
 
+  '@fluid-internal/client-utils@2.33.2':
+    resolution: {integrity: sha512-u3TpcyjCfdDSW6G9+YuGHHQjXq1UVOsF8lzuGhZVazEN+TwzFSGE8wlxgW092TEHo04unbSpI0bp3Jz0qidh/g==}
+
   '@fluid-internal/client-utils@2.42.0':
     resolution: {integrity: sha512-bFzmCoyDvgtnRHUZElJcITZyNJp6WxbgJH6qJvFTgXGwgAZv3058RKRPNT6fl148Tq9ZJ54wLQIOnMzaM9TSfw==}
 
@@ -3052,6 +3055,9 @@ packages:
     engines: {node: '>=20.19.0'}
     hasBin: true
 
+  '@fluidframework/aqueduct@2.33.2':
+    resolution: {integrity: sha512-67a4+EymPZ6ofEAw5wKnvG4WFmaUrfs8sPcj5pQUP8lelk8iIo8m5xjz7tdUuWNHqc18vMauSE3vqAMk4m+9wg==}
+
   '@fluidframework/aqueduct@2.42.0':
     resolution: {integrity: sha512-KpMC7W3e5faHP3Ac2FTD91qMkXEDwvESnxku88GNzLtMFkljfijmG6d8oLxXryjgIA2qO81SH9GTdC8EJFr3jQ==}
 
@@ -3061,41 +3067,74 @@ packages:
   '@fluidframework/common-utils@3.1.0':
     resolution: {integrity: sha512-KpBQqpZKAHCKFMoxtAdrgqL1nIJhT7r2IRGmS3Rm5CMTLsegQ8ifX5lFvd6IbjeWmvLz1qLsY3eS5HBYqy9CVQ==}
 
+  '@fluidframework/container-definitions@2.33.2':
+    resolution: {integrity: sha512-1TkBeikjk3KCqyLR1oseYciUcsN9OlCE/YfjGu/XfdLGTTMe+71/MOBsO9Ob3sS1Q+sIcf32DSMy34oZChafFg==}
+
   '@fluidframework/container-definitions@2.42.0':
     resolution: {integrity: sha512-HNRZ6Xi4JSEd0vIOhOSj+0oeEsgSsYx/TILM0POo3CE0fDfEW6LEHEoknacrM07dJbo2iIlok5VDLpjpycs43w==}
+
+  '@fluidframework/container-loader@2.33.2':
+    resolution: {integrity: sha512-uTWD11iNoDT+E/e02gpwwEY7kEdnsT+fuch4+2uDunUxKcs/lBmoroYjkA7OJRp0rbdHLGINwkqmMo9LJJwkDg==}
 
   '@fluidframework/container-loader@2.42.0':
     resolution: {integrity: sha512-73G3cAztVA7/Rx08tlC8qFkUvvrl2E/AXtfi8KwJFgGNEPNC11rmg23uSXK1889s96LvZvq+ndVTPVFBVzLRWg==}
 
+  '@fluidframework/container-runtime-definitions@2.33.2':
+    resolution: {integrity: sha512-ADM3KH+T9PoTsc9f3t0JSFzStKjSg0pCcIPO9SUICFQFKrbv1BgVzj6UE74IjYNFrdFMmQJvAbZ/4/xEtQcCQw==}
+
   '@fluidframework/container-runtime-definitions@2.42.0':
     resolution: {integrity: sha512-ar+FBKGGp0CZBnETamr0qm7ZzbM4ILzJDkvrJmg/qRYNKNsqati2cXRW2wN/nVvqRooXabJU9Il+gE9DWr6Z8g==}
+
+  '@fluidframework/container-runtime@2.33.2':
+    resolution: {integrity: sha512-K2Z7QdyyEehXROD908zwQ7vtNFiPQWbyfjHcnqundmmKpPcl7J0IibeLltA74rXPkcNEQywaN6QnoNyGRqlt6Q==}
 
   '@fluidframework/container-runtime@2.42.0':
     resolution: {integrity: sha512-l5Wg9dmLX/AWv6UB0dL3A/Ez3yZFk97pt1bHsE2YGrXJxdG6q2JtdIo7c9qU7Pat3s9Q9XFe50DpZK8jzX4Ocw==}
 
+  '@fluidframework/core-interfaces@2.33.2':
+    resolution: {integrity: sha512-2LxpUH9pvZVLmttJK7YLr/z1cXIMGrKwRkZBe++mjz04+gATSPYEWaw24eSfPB1g5CQhRUZZm3mBZRNmvi9TIQ==}
+
   '@fluidframework/core-interfaces@2.42.0':
     resolution: {integrity: sha512-VD2CISocDm52E4HGFZiKr1v7iaaz2dgxLzeJjBgH152ye0G9oCRei9wwxgmH3PBzPm62Xfm/c87hVyHuleVZbQ==}
+
+  '@fluidframework/core-utils@2.33.2':
+    resolution: {integrity: sha512-H5osjGOdutTGumILp9fbVUj6v8cyNCnWJjD9bAWlnVTSvRQkKfqfbXg8XerWgMlPI8EzMq2d2+YUKSFSuJvStw==}
 
   '@fluidframework/core-utils@2.42.0':
     resolution: {integrity: sha512-80llo0gsUfAvt9qBtJsGuhJc2OBB+2EeGQwaq8mEQBIFa7An8NvXLRwKNYsoZjhuG48Xqyxe1n5edW4UcU1WhA==}
 
+  '@fluidframework/datastore-definitions@2.33.2':
+    resolution: {integrity: sha512-iY4WqkC2YN4Un3K3mF8ldasp3hN7aS0x6pW90aiJsED91c++ieCdZK3O9r3EZF+YNPYxC9gkwxnHHivkhatMeQ==}
+
   '@fluidframework/datastore-definitions@2.42.0':
     resolution: {integrity: sha512-kovQgBR1DEKjLbVa+LdlX5FSZjfxyISg5c3iXWDWBvnzKQ6UzH7UYNgW4dAcWqMNbwKgTj2kAYZSIv1NIG8HGg==}
+
+  '@fluidframework/datastore@2.33.2':
+    resolution: {integrity: sha512-IHNshgPssZtz2CsyjHolee3lC2g5ZDdXgaim/f8JphwU1JFDTtOM8c7FABgMrlcF+W+kKCcuazVKMNy231a9Dg==}
 
   '@fluidframework/datastore@2.42.0':
     resolution: {integrity: sha512-JK8/Fl8HCy+Ya2rsiZSj5umEjDMOwNp5H1Dp5Blk2der+zUwK1tv+X7eQNBBEpvty9JuCxPXWSvrG2m+XeiggA==}
 
+  '@fluidframework/driver-base@2.33.2':
+    resolution: {integrity: sha512-GAlT20v8810RGvsuHXShl3mxa0mnGDhfiLMOAunEPjEu/8UDGz7hMOg/XLY2OrsRMlRp6XIF9Op8OYkKsheitw==}
+
   '@fluidframework/driver-base@2.42.0':
     resolution: {integrity: sha512-8+C11OAn0k/i5lDzhT/Kb9KBitee+RBaQQ/flzbV9OzNp3wRp/BaCnaYbNvpeC3qhEWIsYTKk0gooW+RNlVXOg==}
+
+  '@fluidframework/driver-definitions@2.33.2':
+    resolution: {integrity: sha512-2/5AWStdvqxojj/QM8xsu0lFZxmunu0fgW2Nrw/MUqrM0G+TeXMLpieyKVjAvbuhJAmqMFGWVoUrjuKQaXsaxg==}
 
   '@fluidframework/driver-definitions@2.42.0':
     resolution: {integrity: sha512-8eeA/5u5s09tsinv1PaMZL/CdrT7Pb+vZBJ4rVQjLe9+dxcfh5ty6P5K6UqU6jMnEH/tGU4JmTyoPV6qJqv1bA==}
 
+  '@fluidframework/driver-utils@2.33.2':
+    resolution: {integrity: sha512-8d2rcpzMw2XWUc8IRSUJ/FSbGYOKlBuoNfkji7bSiwm6rhUanzLmFcqRvUZlEltY1YzvCXfpcMoW4naYFfWWsA==}
+
   '@fluidframework/driver-utils@2.42.0':
     resolution: {integrity: sha512-9sRkBpT7dWHeVatD0Q/5FpAFsinxeVWxCkDj7sKyGD3Nb2uvkf8iBYA4kpH3KwdtyVngKV2hUBXJls1fAsnODQ==}
 
-  '@fluidframework/fluid-static@2.42.0':
-    resolution: {integrity: sha512-l2gC68n0Z7ARht3C136qhFsIY/qGe6ty+hrF/gD6Ye9S68aIyevCks0c1/3WN6x4GmtQJn5y/LHZzwV1f6RW9g==}
+  '@fluidframework/fluid-static@2.33.2':
+    resolution: {integrity: sha512-lBXJTPLMedENuiHh228HGm6YEbGsKPAbnVOp2PpEZMejVPEZ2Ci+2yk2sPsIYY5hL29gEDFlCB7FlaRUjxaMtQ==}
 
   '@fluidframework/gitresources@5.0.0':
     resolution: {integrity: sha512-nfam1KT+EUqFCENHcxrU9VwUfbhUC83UcLuOsdLpn9I7VuClL+w8KMWosoYauZraO9gDhTo2kCErjgQji5GzGA==}
@@ -3103,14 +3142,23 @@ packages:
   '@fluidframework/gitresources@6.0.0':
     resolution: {integrity: sha512-/GOi0mLrjsrzFCIbMcEK9E8f64e1NBee6eScMrPJMj2oVljF2bAryrQm0SuZzC6x/lG3Ot5OXnBWHu+jSFyQiw==}
 
+  '@fluidframework/id-compressor@2.33.2':
+    resolution: {integrity: sha512-nY7xsr7H05QE13YiNU4VjO/y9DFejXe0h0nEavu0kbFnTi1T+W//mW7BurblW6DwFy7vRfAcWq8UjDajy0kSIA==}
+
   '@fluidframework/id-compressor@2.42.0':
     resolution: {integrity: sha512-IyjZp7ocCdjFvdLC1HmAGd2mliPoSazBGkrwbMijHaIp+dDJ6GEIafIddswla6N4z3Pf06KqxD0YPTmCpk8N+A==}
 
   '@fluidframework/local-driver@2.42.0':
     resolution: {integrity: sha512-QPWJlJm95QBEvKK/8gqq71ZNNaKS5CjHVlXwvdJwZHhb3ohK7yHy6QabQiYxSxLzFJQ91c3SCcli+NSQ+lLziA==}
 
+  '@fluidframework/map@2.33.2':
+    resolution: {integrity: sha512-OSVVghQ6shi9YNJunSGFiQ+aGNi4SWOw6Isd3Fu7EW0H2WyoD/QB6ipaSJMW38eBpgr5XCWKgt6fsi2Ymuh4zA==}
+
   '@fluidframework/map@2.42.0':
     resolution: {integrity: sha512-RCzZCORNoPbVSlQTp7x0CuKEGLt8PbDfZoOHMTEojRjG+3NuyKt9oyZtV6gp9p4tFE2hRFaMTPxHdTNVvVPAdw==}
+
+  '@fluidframework/merge-tree@2.33.2':
+    resolution: {integrity: sha512-L3bzJoFtvWX9yOwcwEfesEJVjBymLTnksxyCF85kaO8EnKxbJY2kCQ4eL1Bkj0fYT8wWoLGRz4wpPYGzvc7uqw==}
 
   '@fluidframework/merge-tree@2.42.0':
     resolution: {integrity: sha512-5Ta6R8Re7HIJCfwHNfrkP9uZmvmH3QRlctQTi6/Bn7lYaOSBd32Ue9uxsXwg5smbF18dXXCzJxr87+WYDoXLJg==}
@@ -3133,14 +3181,26 @@ packages:
   '@fluidframework/protocol-definitions@3.2.0':
     resolution: {integrity: sha512-xgcyMN4uF6dAp2/XYFSHvGFITIV7JbVt3itA+T0c71/lZjq/HU/a/ClPIxfl9AEN0RbtuR/1n5LP4FXSV9j0hA==}
 
+  '@fluidframework/request-handler@2.33.2':
+    resolution: {integrity: sha512-Jv1AAXmlbOSu6cep9G1ARkG7zh5ftp2qDkWSchyl63kBIYsYslNqXhKaeEGKi7ZHPMgg4tip3iezTAAPD0R19g==}
+
   '@fluidframework/request-handler@2.42.0':
     resolution: {integrity: sha512-EoqHL6hr1KbmjIrz4AB8ORGdSge7vxAuGNGE7JyDL24YB/ApLi3f31OgomRMWSi6msUuEGVqcNH3QwKxzxNQpQ==}
+
+  '@fluidframework/routerlicious-driver@2.33.2':
+    resolution: {integrity: sha512-P4pmg9Wolp+HxMQLoI9zHozSowENIce6G8aaNS/P/vDHpOlkfLtT36FBmM4wkirWC3dS0WOtu9wleDgaYbDfAA==}
 
   '@fluidframework/routerlicious-driver@2.42.0':
     resolution: {integrity: sha512-wYoUuO5hyoKEK9GeyWHJVzlAjw4PyxZZ1zpI/skcR45UnkWO10GVx2nKSIQNPl5TjjCFn2vsNqSuJ2PAEWgoBw==}
 
+  '@fluidframework/runtime-definitions@2.33.2':
+    resolution: {integrity: sha512-hZFTTKg+p8CQ0pdzGteY4Ej/fMbt3ZQ9F+cp+p7QG1EWDoiQMq40pEQ6R0M0WQEoiMfTskq1vA+8I1MjwotKAg==}
+
   '@fluidframework/runtime-definitions@2.42.0':
     resolution: {integrity: sha512-1eCdf3mX0dPMu9Bxv2k9HNDCtpVLMbqEA2nVpaL7SRz+ogKkYv9GbWLWEyFZ9EsMOcNrZsIDCahM7TCm3JhmxA==}
+
+  '@fluidframework/runtime-utils@2.33.2':
+    resolution: {integrity: sha512-4k8yIMv6WQ0ZJ1Bq0Z12HBGWi7q0xfe7+AELG33N+6PFOAM9vZXw0QY5RxSTBi+DIUZJfR9CdFO6auP18nU0dg==}
 
   '@fluidframework/runtime-utils@2.42.0':
     resolution: {integrity: sha512-RUlltVnkmdBN7qIOGIv1oVMSKDDRkkGfAv2CY3lyqSV4eDmR8eBW3tsTpqnl3Tm6xczkrhur5J1dBYmzJP2yxQ==}
@@ -3199,11 +3259,20 @@ packages:
   '@fluidframework/server-test-utils@6.0.0':
     resolution: {integrity: sha512-fbopMKb7t/Sp1YtEoIMFpD/cdy5nan/XCy54ouL27DavRCBLdgLBY9OH+5VBsLiEGCOT+vKCSq5/hqnaP8dpQQ==}
 
+  '@fluidframework/shared-object-base@2.33.2':
+    resolution: {integrity: sha512-KL9Mp9RXr5HtoKACephgtv/IbAKJQgYtPTM/t5Z1dLKUuEVz7TJzLpqFdOZ/NPelrg8LkSTtvjedK8QomUAScQ==}
+
   '@fluidframework/shared-object-base@2.42.0':
     resolution: {integrity: sha512-nd1+TvQSJpz9yNUh8CYVBBPtA/kX3r5++4VhxLm8yuNxgxumGOXbTeO23zw1U79Tbcnm0dEzY/rPMKTp7LjL4Q==}
 
+  '@fluidframework/synthesize@2.33.2':
+    resolution: {integrity: sha512-eDUpYFG8NfdEWHsz9CCmW0VcTmOseVhEkT4s275u8h6MWJ1HrihV+fMdcBKMwzBxoIQwVLMFLmqY0MMK5nSdMA==}
+
   '@fluidframework/synthesize@2.42.0':
     resolution: {integrity: sha512-+EzHjg3vbWJH7iiNLTeW85jWs4y3AlWgvkZooxH1h9fXgTCqejLfPDzBM+3P5gMlKMs/CXym79BzpJBfcNHhzA==}
+
+  '@fluidframework/telemetry-utils@2.33.2':
+    resolution: {integrity: sha512-vhUnSg5mBksmdwGQkkC6oIcoyiZsj039sWAKEzmMJWKBpj4t+r9ahomjS0/abTsDbBgmSNxIa3CVUZn3E3nUEw==}
 
   '@fluidframework/telemetry-utils@2.42.0':
     resolution: {integrity: sha512-uQnX3o3aXIIzjzvF1Ej5EIUUZ87Q/fIWzzXE+5fUybuxglfXOBB6Vo37Nps4Afe0R7wLkQwijJ5wop96UYTETw==}
@@ -3211,8 +3280,11 @@ packages:
   '@fluidframework/test-utils@2.42.0':
     resolution: {integrity: sha512-kfjy7X6269k0E58RfJgHQYW027l4vM7lmHhg4eZ0ZW432d5xF6p9pKLbwKjmIfKbJ8kwP4xPszBLys3tp9IuyQ==}
 
-  '@fluidframework/tinylicious-driver@2.42.0':
-    resolution: {integrity: sha512-uIkEQTltGYSaD89s9SRZh0Ab/CEW2OKe767FOU0cu4Us/kmPXBUGnYQE0OBIPcOpz2hZMcC/mr+qONHQL9ej9Q==}
+  '@fluidframework/tinylicious-driver@2.33.2':
+    resolution: {integrity: sha512-vO9v6n3YPM6JGaw0XANVT0NFJggbEVLR7xWSMV01YAkEoyA/cyEdjaAfmyAVIoXb4JARAhw1dIctJh+XkhbZrg==}
+
+  '@fluidframework/tree@2.33.2':
+    resolution: {integrity: sha512-CeOGzpQ8EqJ/j3RfwjhgCLhXVokIkSHiOrCw+THnXT321/QL0n7LNIwHAumP2yQVhwRK+MIo8XxYeRSyicOjyw==}
 
   '@fluidframework/tree@2.42.0':
     resolution: {integrity: sha512-A4scYdxnL9pOlaGTtffO77T3pBaVLLmnKOUtUcRy7OSoZinIPJDQq0RaUDhT3c6VSnVZq2E+ZRYGLd9okwdCnA==}
@@ -13639,6 +13711,16 @@ snapshots:
       mdast-util-find-and-replace: 1.1.1
       unist-util-visit: 2.0.3
 
+  '@fluid-internal/client-utils@2.33.2':
+    dependencies:
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@types/events_pkg': '@types/events@3.0.3'
+      base64-js: 1.5.1
+      buffer: 6.0.3
+      events_pkg: events@3.3.0
+      sha.js: 2.4.12
+
   '@fluid-internal/client-utils@2.42.0':
     dependencies:
       '@fluidframework/core-interfaces': 2.42.0
@@ -13696,6 +13778,28 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@fluidframework/aqueduct@2.33.2':
+    dependencies:
+      '@fluid-internal/client-utils': 2.33.2
+      '@fluidframework/container-definitions': 2.33.2
+      '@fluidframework/container-runtime': 2.33.2
+      '@fluidframework/container-runtime-definitions': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@fluidframework/datastore': 2.33.2
+      '@fluidframework/datastore-definitions': 2.33.2
+      '@fluidframework/map': 2.33.2
+      '@fluidframework/request-handler': 2.33.2
+      '@fluidframework/runtime-definitions': 2.33.2
+      '@fluidframework/runtime-utils': 2.33.2
+      '@fluidframework/shared-object-base': 2.33.2
+      '@fluidframework/synthesize': 2.33.2
+      '@fluidframework/telemetry-utils': 2.33.2
+      '@fluidframework/tree': 2.33.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@fluidframework/aqueduct@2.42.0':
     dependencies:
       '@fluid-internal/client-utils': 2.42.0
@@ -13730,10 +13834,33 @@ snapshots:
       lodash: 4.17.23
       sha.js: 2.4.12
 
+  '@fluidframework/container-definitions@2.33.2':
+    dependencies:
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+
   '@fluidframework/container-definitions@2.42.0':
     dependencies:
       '@fluidframework/core-interfaces': 2.42.0
       '@fluidframework/driver-definitions': 2.42.0
+
+  '@fluidframework/container-loader@2.33.2':
+    dependencies:
+      '@fluid-internal/client-utils': 2.33.2
+      '@fluidframework/container-definitions': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/driver-utils': 2.33.2(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.33.2
+      '@types/events_pkg': '@types/events@3.0.3'
+      '@ungap/structured-clone': 1.3.0
+      debug: 4.4.3(supports-color@8.1.1)
+      double-ended-queue: 2.1.0-0
+      events_pkg: events@3.3.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@fluidframework/container-loader@2.42.0':
     dependencies:
@@ -13753,6 +13880,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@fluidframework/container-runtime-definitions@2.33.2':
+    dependencies:
+      '@fluidframework/container-definitions': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/runtime-definitions': 2.33.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@fluidframework/container-runtime-definitions@2.42.0':
     dependencies:
       '@fluid-internal/client-utils': 2.42.0
@@ -13761,6 +13897,29 @@ snapshots:
       '@fluidframework/driver-definitions': 2.42.0
       '@fluidframework/runtime-definitions': 2.42.0
     transitivePeerDependencies:
+      - supports-color
+
+  '@fluidframework/container-runtime@2.33.2':
+    dependencies:
+      '@fluid-internal/client-utils': 2.33.2
+      '@fluidframework/container-definitions': 2.33.2
+      '@fluidframework/container-runtime-definitions': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@fluidframework/datastore': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/driver-utils': 2.33.2(debug@4.4.3)
+      '@fluidframework/id-compressor': 2.33.2
+      '@fluidframework/runtime-definitions': 2.33.2
+      '@fluidframework/runtime-utils': 2.33.2
+      '@fluidframework/telemetry-utils': 2.33.2
+      '@tylerbu/sorted-btree-es6': 1.8.0
+      double-ended-queue: 2.1.0-0
+      lz4js: 0.2.0
+      semver-ts: 1.0.3
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - debug
       - supports-color
 
   '@fluidframework/container-runtime@2.42.0(debug@4.4.3)':
@@ -13786,9 +13945,23 @@ snapshots:
       - debug
       - supports-color
 
+  '@fluidframework/core-interfaces@2.33.2': {}
+
   '@fluidframework/core-interfaces@2.42.0': {}
 
+  '@fluidframework/core-utils@2.33.2': {}
+
   '@fluidframework/core-utils@2.42.0': {}
+
+  '@fluidframework/datastore-definitions@2.33.2':
+    dependencies:
+      '@fluidframework/container-definitions': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/id-compressor': 2.33.2
+      '@fluidframework/runtime-definitions': 2.33.2
+    transitivePeerDependencies:
+      - supports-color
 
   '@fluidframework/datastore-definitions@2.42.0':
     dependencies:
@@ -13798,6 +13971,24 @@ snapshots:
       '@fluidframework/id-compressor': 2.42.0
       '@fluidframework/runtime-definitions': 2.42.0
     transitivePeerDependencies:
+      - supports-color
+
+  '@fluidframework/datastore@2.33.2':
+    dependencies:
+      '@fluid-internal/client-utils': 2.33.2
+      '@fluidframework/container-definitions': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@fluidframework/datastore-definitions': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/driver-utils': 2.33.2(debug@4.4.3)
+      '@fluidframework/id-compressor': 2.33.2
+      '@fluidframework/runtime-definitions': 2.33.2
+      '@fluidframework/runtime-utils': 2.33.2
+      '@fluidframework/telemetry-utils': 2.33.2
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - debug
       - supports-color
 
   '@fluidframework/datastore@2.42.0(debug@4.4.3)':
@@ -13818,6 +14009,18 @@ snapshots:
       - debug
       - supports-color
 
+  '@fluidframework/driver-base@2.33.2':
+    dependencies:
+      '@fluid-internal/client-utils': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/driver-utils': 2.33.2(debug@4.4.3)
+      '@fluidframework/telemetry-utils': 2.33.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@fluidframework/driver-base@2.42.0(debug@4.4.3)':
     dependencies:
       '@fluid-internal/client-utils': 2.42.0
@@ -13830,9 +14033,27 @@ snapshots:
       - debug
       - supports-color
 
+  '@fluidframework/driver-definitions@2.33.2':
+    dependencies:
+      '@fluidframework/core-interfaces': 2.33.2
+
   '@fluidframework/driver-definitions@2.42.0':
     dependencies:
       '@fluidframework/core-interfaces': 2.42.0
+
+  '@fluidframework/driver-utils@2.33.2(debug@4.4.3)':
+    dependencies:
+      '@fluid-internal/client-utils': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/telemetry-utils': 2.33.2
+      axios: 1.13.5(debug@4.4.3)
+      lz4js: 0.2.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   '@fluidframework/driver-utils@2.42.0(debug@4.4.3)':
     dependencies:
@@ -13848,23 +14069,22 @@ snapshots:
       - debug
       - supports-color
 
-  '@fluidframework/fluid-static@2.42.0':
+  '@fluidframework/fluid-static@2.33.2':
     dependencies:
-      '@fluid-internal/client-utils': 2.42.0
-      '@fluidframework/aqueduct': 2.42.0
-      '@fluidframework/container-definitions': 2.42.0
-      '@fluidframework/container-loader': 2.42.0
-      '@fluidframework/container-runtime': 2.42.0(debug@4.4.3)
-      '@fluidframework/container-runtime-definitions': 2.42.0
-      '@fluidframework/core-interfaces': 2.42.0
-      '@fluidframework/core-utils': 2.42.0
-      '@fluidframework/datastore-definitions': 2.42.0
-      '@fluidframework/driver-definitions': 2.42.0
-      '@fluidframework/request-handler': 2.42.0(debug@4.4.3)
-      '@fluidframework/runtime-definitions': 2.42.0
-      '@fluidframework/runtime-utils': 2.42.0(debug@4.4.3)
-      '@fluidframework/shared-object-base': 2.42.0(debug@4.4.3)
-      '@fluidframework/telemetry-utils': 2.42.0
+      '@fluid-internal/client-utils': 2.33.2
+      '@fluidframework/aqueduct': 2.33.2
+      '@fluidframework/container-definitions': 2.33.2
+      '@fluidframework/container-loader': 2.33.2
+      '@fluidframework/container-runtime': 2.33.2
+      '@fluidframework/container-runtime-definitions': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/datastore-definitions': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/request-handler': 2.33.2
+      '@fluidframework/runtime-definitions': 2.33.2
+      '@fluidframework/runtime-utils': 2.33.2
+      '@fluidframework/shared-object-base': 2.33.2
+      '@fluidframework/telemetry-utils': 2.33.2
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13872,6 +14092,17 @@ snapshots:
   '@fluidframework/gitresources@5.0.0': {}
 
   '@fluidframework/gitresources@6.0.0': {}
+
+  '@fluidframework/id-compressor@2.33.2':
+    dependencies:
+      '@fluid-internal/client-utils': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@fluidframework/telemetry-utils': 2.33.2
+      '@tylerbu/sorted-btree-es6': 1.8.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@fluidframework/id-compressor@2.42.0':
     dependencies:
@@ -13908,6 +14139,24 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@fluidframework/map@2.33.2':
+    dependencies:
+      '@fluid-internal/client-utils': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@fluidframework/datastore-definitions': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/driver-utils': 2.33.2(debug@4.4.3)
+      '@fluidframework/merge-tree': 2.33.2
+      '@fluidframework/runtime-definitions': 2.33.2
+      '@fluidframework/runtime-utils': 2.33.2
+      '@fluidframework/shared-object-base': 2.33.2
+      '@fluidframework/telemetry-utils': 2.33.2
+      path-browserify: 1.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@fluidframework/map@2.42.0(debug@4.4.3)':
     dependencies:
       '@fluid-internal/client-utils': 2.42.0
@@ -13922,6 +14171,22 @@ snapshots:
       '@fluidframework/shared-object-base': 2.42.0(debug@4.4.3)
       '@fluidframework/telemetry-utils': 2.42.0
       path-browserify: 1.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@fluidframework/merge-tree@2.33.2':
+    dependencies:
+      '@fluid-internal/client-utils': 2.33.2
+      '@fluidframework/container-definitions': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@fluidframework/datastore-definitions': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/runtime-definitions': 2.33.2
+      '@fluidframework/runtime-utils': 2.33.2
+      '@fluidframework/shared-object-base': 2.33.2
+      '@fluidframework/telemetry-utils': 2.33.2
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -13997,6 +14262,17 @@ snapshots:
 
   '@fluidframework/protocol-definitions@3.2.0': {}
 
+  '@fluidframework/request-handler@2.33.2':
+    dependencies:
+      '@fluidframework/container-runtime-definitions': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@fluidframework/runtime-definitions': 2.33.2
+      '@fluidframework/runtime-utils': 2.33.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@fluidframework/request-handler@2.42.0(debug@4.4.3)':
     dependencies:
       '@fluidframework/container-runtime-definitions': 2.42.0
@@ -14007,6 +14283,27 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
+
+  '@fluidframework/routerlicious-driver@2.33.2(encoding@0.1.13)':
+    dependencies:
+      '@fluid-internal/client-utils': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@fluidframework/driver-base': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/driver-utils': 2.33.2(debug@4.4.3)
+      '@fluidframework/server-services-client': 5.0.0
+      '@fluidframework/telemetry-utils': 2.33.2
+      cross-fetch: 3.2.0(encoding@0.1.13)
+      json-stringify-safe: 5.0.1
+      socket.io-client: 4.7.5
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
 
   '@fluidframework/routerlicious-driver@2.42.0(debug@4.4.3)(encoding@0.1.13)':
     dependencies:
@@ -14029,6 +14326,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@fluidframework/runtime-definitions@2.33.2':
+    dependencies:
+      '@fluidframework/container-definitions': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/id-compressor': 2.33.2
+      '@fluidframework/telemetry-utils': 2.33.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@fluidframework/runtime-definitions@2.42.0':
     dependencies:
       '@fluidframework/container-definitions': 2.42.0
@@ -14037,6 +14344,22 @@ snapshots:
       '@fluidframework/id-compressor': 2.42.0
       '@fluidframework/telemetry-utils': 2.42.0
     transitivePeerDependencies:
+      - supports-color
+
+  '@fluidframework/runtime-utils@2.33.2':
+    dependencies:
+      '@fluid-internal/client-utils': 2.33.2
+      '@fluidframework/container-definitions': 2.33.2
+      '@fluidframework/container-runtime-definitions': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@fluidframework/datastore-definitions': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/driver-utils': 2.33.2(debug@4.4.3)
+      '@fluidframework/runtime-definitions': 2.33.2
+      '@fluidframework/telemetry-utils': 2.33.2
+    transitivePeerDependencies:
+      - debug
       - supports-color
 
   '@fluidframework/runtime-utils@2.42.0(debug@4.4.3)':
@@ -14409,6 +14732,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@fluidframework/shared-object-base@2.33.2':
+    dependencies:
+      '@fluid-internal/client-utils': 2.33.2
+      '@fluidframework/container-definitions': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@fluidframework/datastore': 2.33.2
+      '@fluidframework/datastore-definitions': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/runtime-definitions': 2.33.2
+      '@fluidframework/runtime-utils': 2.33.2
+      '@fluidframework/telemetry-utils': 2.33.2
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@fluidframework/shared-object-base@2.42.0(debug@4.4.3)':
     dependencies:
       '@fluid-internal/client-utils': 2.42.0
@@ -14427,9 +14767,24 @@ snapshots:
       - debug
       - supports-color
 
+  '@fluidframework/synthesize@2.33.2':
+    dependencies:
+      '@fluidframework/core-utils': 2.33.2
+
   '@fluidframework/synthesize@2.42.0':
     dependencies:
       '@fluidframework/core-utils': 2.42.0
+
+  '@fluidframework/telemetry-utils@2.33.2':
+    dependencies:
+      '@fluid-internal/client-utils': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      debug: 4.4.3(supports-color@8.1.1)
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@fluidframework/telemetry-utils@2.42.0':
     dependencies:
@@ -14474,12 +14829,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@fluidframework/tinylicious-driver@2.42.0(encoding@0.1.13)':
+  '@fluidframework/tinylicious-driver@2.33.2(encoding@0.1.13)':
     dependencies:
-      '@fluidframework/core-interfaces': 2.42.0
-      '@fluidframework/driver-definitions': 2.42.0
-      '@fluidframework/driver-utils': 2.42.0(debug@4.4.3)
-      '@fluidframework/routerlicious-driver': 2.42.0(debug@4.4.3)(encoding@0.1.13)
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/driver-utils': 2.33.2(debug@4.4.3)
+      '@fluidframework/routerlicious-driver': 2.33.2(encoding@0.1.13)
       jsrsasign: 11.1.0
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -14488,6 +14843,28 @@ snapshots:
       - encoding
       - supports-color
       - utf-8-validate
+
+  '@fluidframework/tree@2.33.2':
+    dependencies:
+      '@fluid-internal/client-utils': 2.33.2
+      '@fluidframework/container-runtime': 2.33.2
+      '@fluidframework/core-interfaces': 2.33.2
+      '@fluidframework/core-utils': 2.33.2
+      '@fluidframework/datastore-definitions': 2.33.2
+      '@fluidframework/driver-definitions': 2.33.2
+      '@fluidframework/id-compressor': 2.33.2
+      '@fluidframework/runtime-definitions': 2.33.2
+      '@fluidframework/runtime-utils': 2.33.2
+      '@fluidframework/shared-object-base': 2.33.2
+      '@fluidframework/telemetry-utils': 2.33.2
+      '@sinclair/typebox': 0.34.48
+      '@tylerbu/sorted-btree-es6': 1.8.0
+      '@types/ungap__structured-clone': 1.2.0
+      '@ungap/structured-clone': 1.3.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   '@fluidframework/tree@2.42.0':
     dependencies:

--- a/syncpack.config.cjs
+++ b/syncpack.config.cjs
@@ -34,6 +34,12 @@ const config = {
 			packages: ["@tylerbu/sorted-btree-es6"],
 		},
 		{
+			label: "Ignore levee-client package (being removed from monorepo)",
+			isIgnored: true,
+			dependencies: ["**"],
+			packages: ["@tylerbu/levee-client"],
+		},
+		{
 			label: "Use >= range for repopo peer dependency in sort-tsconfig",
 			dependencies: ["repopo"],
 			dependencyTypes: ["peer"],
@@ -86,6 +92,12 @@ const config = {
 			isIgnored: true,
 			dependencies: ["**"],
 			packages: ["@tylerbu/sorted-btree-es6"],
+		},
+		{
+			label: "Ignore levee-client package (being removed from monorepo)",
+			isIgnored: true,
+			dependencies: ["**"],
+			packages: ["@tylerbu/levee-client"],
 		},
 		{
 			label: "Ignore packageManager field",


### PR DESCRIPTION
## Summary

- Bump vitest and @vitest/coverage-v8 from ^4.0.17 to ^4.0.18
- Bump @biomejs/biome from 2.0.4 to 2.3.8 in config
- Bump unified peer dep from ^11.0.0 to ^11.0.5 in remark/rehype plugins
- Upgrade syncpack from ^13.0.4 to 14.0.0-alpha.37 with v14 config (dependency groups, improved semver rules)
- Add biome override to disable noShadow for auto-generated TypeScript files
- Add esm/ and dist/ to nx production input exclusions
- Add build:compile dependency to build:vite target
- Improve .gitignore patterns (global esm/, dist/, coverage/ patterns)

## Test plan

- [ ] CI passes (build, lint, test)
- [ ] `pnpm syncpack:fix` works with new syncpack v14 config
- [ ] `pnpm check` passes