### PR TITLE
fix(btree-typescript): remove prepare script

### DIFF
--- a/packages/btree-typescript/package.json
+++ b/packages/btree-typescript/package.json
@@ -33,7 +33,6 @@
     "build": "npm run clean && tsc && npm run minify",
     "minify": "node scripts/minify.js",
     "sizes": "npm run build && node scripts/size-report.js",
-    "prepare": "npm run build",
     "safePublish": "npm run build && testpack && npm publish",
     "benchmark": "npm run build && node benchmarks.js"
   },


### PR DESCRIPTION
## Summary

- Remove the `prepare` script from `btree-typescript`'s `package.json`, which was running a full build (`npm run build`) on every `pnpm install` at the workspace root. Build orchestration is handled by Nx and doesn't need a lifecycle hook.