### PR TITLE
feat(astro-tinylytics): add core components, types, URL utilities, and tests

### DIFF
--- a/.changeset/astro-tinylytics-core-components.md
+++ b/.changeset/astro-tinylytics-core-components.md
@@ -2,4 +2,12 @@
 "astro-tinylytics": minor
 ---
 
-Add core Tinylytics components (`Script`, `Hits`, `Kudos`, `Countries`, `Uptime`, `Webring`, `Event`, `Pixel`), shared prop types, `buildScriptUrl`/`buildPixelUrl` URL utilities, and a vitest test suite using the Astro Container API.
+Adds a full set of Astro components covering every Tinylytics widget and script option:
+
+- `Script` — renders the Tinylytics embed `<script>` with typed props for every documented URL parameter (`hits`, `kudos`, `uptime`, `countries`, `webring`, `events`, `beacon`, `spa`, `ignore`, `min`, `defer`).
+- `Hits`, `Kudos`, `Countries`, `Uptime` — widget elements that render the markup Tinylytics looks for. Each accepts an `as` prop to override the tag and a `class` prop to append extra class names, and can be opted out of tracking with `ignore`.
+- `Webring` — renders the webring anchor, with optional avatar image (`avatar`, `avatarPosition`, `avatarAlt`) and `newTab` control.
+- `Event` — wraps any element with Tinylytics event-tracking data attributes; auto-renders as `<a>` when `href` is present, `<button>` otherwise, or an explicit tag via `as`.
+- `Pixel` — renders a 1×1 tracking image for RSS feeds, HTML email, and other no-JavaScript contexts.
+
+Also exports `buildScriptUrl` and `buildPixelUrl` helpers for consumers that want to construct Tinylytics URLs directly.

--- a/.changeset/astro-tinylytics-core-components.md
+++ b/.changeset/astro-tinylytics-core-components.md
@@ -1,0 +1,5 @@
+---
+"astro-tinylytics": minor
+---
+
+Add core Tinylytics components (`Script`, `Hits`, `Kudos`, `Countries`, `Uptime`, `Webring`, `Event`, `Pixel`), shared prop types, `buildScriptUrl`/`buildPixelUrl` URL utilities, and a vitest test suite using the Astro Container API.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -102,6 +102,19 @@
 			},
 		},
 		{
+			// Astro component package entry points re-export .astro files directly.
+			// Biome's useImportExtensions rule doesn't recognise .astro as a valid
+			// extension and suggests rewriting to .js, which breaks the imports.
+			"includes": ["packages/astro-tinylytics/**"],
+			"linter": {
+				"rules": {
+					"correctness": {
+						"useImportExtensions": "off",
+					},
+				},
+			},
+		},
+		{
 			// Astro files - biome can parse the frontmatter but not the template
 			// below it, so it treats any variable referenced only in the template
 			// as unused. Disable the affected correctness rules for .astro.

--- a/packages/astro-tinylytics/CHANGELOG.md
+++ b/packages/astro-tinylytics/CHANGELOG.md
@@ -1,0 +1,7 @@
+# astro-tinylytics
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release: Astro components for Tinylytics analytics

--- a/packages/astro-tinylytics/CHANGELOG.md
+++ b/packages/astro-tinylytics/CHANGELOG.md
@@ -1,7 +1,1 @@
 # astro-tinylytics
-
-## 0.1.0
-
-### Minor Changes
-
-- Initial release: Astro components for Tinylytics analytics

--- a/packages/astro-tinylytics/README.md
+++ b/packages/astro-tinylytics/README.md
@@ -1,49 +1,166 @@
-# @tylerbu/astro-tinylytics
+# astro-tinylytics
 
-Astro components for [Tinylytics](https://tinylytics.app) analytics, kudos buttons, and webmentions.
+Astro components for [Tinylytics](https://tinylytics.app) — analytics, kudos, webmentions, event tracking, webrings, and the no-JS tracking pixel.
 
 ## Install
 
 ```sh
-pnpm add @tylerbu/astro-tinylytics
+pnpm add astro-tinylytics
 ```
 
-Astro `^5.0.0` is a peer dependency.
+Astro `>=4.0.0` is a peer dependency.
 
-## Usage
+## Quickstart
 
-### Analytics + webmentions
-
-The `Tinylytics` component renders either the embed `<script>` (with optional `kudos` and `hits` widget flags) or the `<link rel="webmention">` endpoint — but not both at once. Call it twice if you need both.
+Drop the script into your site `<head>` and place widgets where you want them:
 
 ```astro
 ---
-import Tinylytics from "@tylerbu/astro-tinylytics/Tinylytics.astro";
+import { Script, Hits, Kudos, Uptime, Countries, Webring } from "astro-tinylytics";
 ---
 <head>
-  <!-- Webmention endpoint -->
-  <Tinylytics embedCode="YOUR_EMBED_CODE" webmention />
-
-  <!-- Analytics script with kudos (custom mode) + hits widget -->
-  <Tinylytics embedCode="YOUR_EMBED_CODE" kudos="custom" hits />
+  <Script
+    embedCode="YOUR_EMBED_CODE"
+    hits
+    kudos="custom"
+    events
+    beacon
+    uptime
+    countries
+    webring="avatars"
+  />
 </head>
+
+<p>Total visits: <Hits /></p>
+<Kudos path="/posts/hello" />
+<Uptime /> uptime
+<Countries />
+<Webring avatar>Random indie site</Webring>
 ```
 
-Props:
+## Components
 
-| Prop        | Type                       | Default | Notes                                                             |
-| ----------- | -------------------------- | ------- | ----------------------------------------------------------------- |
-| `embedCode` | `string`                   | —       | Required. Your site's Tinylytics embed code.                      |
-| `kudos`     | `boolean \| "custom"`      | `false` | `true` → `?kudos`. `"custom"` → `?kudos=custom` (inject count only). |
-| `hits`      | `boolean \| "unique"`      | `false` | `true` → `?hits`. `"unique"` → `?hits=unique` (paid).             |
-| `webmention`| `true`                     | —       | Mutually exclusive with `kudos` / `hits`.                         |
+### `<Script>`
 
-### Kudos button
+Renders the Tinylytics embed `<script>` with typed props for every documented URL flag. Enable each widget / feature with a boolean prop; the component produces the matching query string.
+
+```astro
+<Script embedCode="YOUR_EMBED_CODE" hits kudos="custom" events beacon />
+<!-- → <script src="https://tinylytics.app/embed/YOUR_EMBED_CODE.js?hits&kudos=custom&events&beacon" defer></script> -->
+```
+
+| Prop        | Type                               | Default | Notes                                                                         |
+| ----------- | ---------------------------------- | ------- | ----------------------------------------------------------------------------- |
+| `embedCode` | `string`                           | —       | Required. Your site's Tinylytics embed code.                                  |
+| `min`       | `boolean`                          | `false` | Load the minified `min.js` build.                                             |
+| `spa`       | `boolean`                          | `false` | Enable client-routed SPA mode.                                                |
+| `ignore`    | `boolean`                          | `false` | Load the script but suppress tracking on this page.                           |
+| `hits`      | `boolean \| "unique"`              | —       | `true` → `?hits`, `"unique"` → `?hits=unique`.                                |
+| `kudos`     | `boolean \| "custom" \| string`    | —       | `true` → `?kudos`, `"custom"` → `?kudos=custom`, or any custom emoji/string.  |
+| `uptime`    | `boolean`                          | `false` | Enable the uptime widget (paid plan).                                         |
+| `countries` | `boolean`                          | `false` | Enable the visitor-countries widget.                                          |
+| `webring`   | `boolean \| "avatars"`             | —       | `true` → `?webring`, `"avatars"` → `?webring=avatars`.                        |
+| `events`    | `boolean`                          | `false` | Enable event tracking (required for `<Event>`).                               |
+| `beacon`    | `boolean`                          | `false` | Use `sendBeacon` so link-click events aren't dropped during navigation.       |
+| `defer`     | `boolean`                          | `true`  | Emit `defer` on the script tag.                                               |
+
+### `<Hits>`, `<Countries>`, `<Uptime>`
+
+Widget elements the Tinylytics script scans for. Each renders an empty `<span>` by default — the script fills in the content on load.
+
+```astro
+<Hits />                          <!-- lifetime hit counter -->
+<Countries as="div" class="flags" />
+<Uptime class="badge" />
+```
+
+| Prop     | Type                         | Default  | Notes                                                       |
+| -------- | ---------------------------- | -------- | ----------------------------------------------------------- |
+| `as`     | `keyof HTMLElementTagNameMap`| `"span"` | Override the tag.                                           |
+| `class`  | `string`                     | —        | Extra class names (merged with the Tinylytics class hook).  |
+| `ignore` | `boolean`                    | `false`  | Set `data-ignore="true"` to exclude this instance.          |
+
+### `<Kudos>`
+
+A low-level kudos button. Leave the slot empty to let Tinylytics inject its default `👋 N` content, or provide your own markup (useful with `kudos="custom"` on `<Script>`).
+
+```astro
+<Kudos path="/posts/hello" />
+<Kudos path="/posts/hello">❤️ Love it</Kudos>
+```
+
+| Prop      | Type      | Default       | Notes                                                                |
+| --------- | --------- | ------------- | -------------------------------------------------------------------- |
+| `path`    | `string`  | current URL   | Pin kudos to a canonical path. Required when multiple buttons share a page. |
+| `private` | `boolean` | `false`       | Count visible only to the site owner.                                |
+| `ignore`  | `boolean` | `false`       | Set `data-ignore="true"`.                                            |
+| `class`   | `string`  | —             | Extra class names.                                                   |
+
+For a higher-level button with icon, label, count threshold, and suffix template, see [`<KudosButton>`](#kudosbutton).
+
+### `<Webring>`
+
+Renders the webring anchor Tinylytics fills with a random ring member on page load. Requires `<Script webring />` (or `webring="avatars"` if `avatar` is used).
+
+```astro
+<Webring>Random indie site</Webring>
+
+<Webring avatar avatarPosition="before" avatarAlt="Current ring member">
+  Visit next
+</Webring>
+```
+
+| Prop             | Type                    | Default    | Notes                                                                                |
+| ---------------- | ----------------------- | ---------- | ------------------------------------------------------------------------------------ |
+| `avatar`         | `boolean`               | `false`    | Render the avatar `<img>`. Script must be loaded with `webring="avatars"`.           |
+| `avatarPosition` | `"before" \| "after"`   | `"before"` | Avatar placement relative to the slot.                                               |
+| `avatarAlt`      | `string`                | `""`       | Avatar `alt` text. Empty string renders `aria-hidden="true"`.                        |
+| `newTab`         | `boolean`               | `true`     | Open in a new tab (`target="_blank" rel="noopener"`).                                |
+| `class`          | `string`                | —          | Extra class names.                                                                   |
+
+### `<Event>`
+
+Wraps any element with Tinylytics event-tracking data attributes. Auto-renders as `<a>` when `href` is present, otherwise `<button>`. Pass `as` to force a tag. Extra HTML attributes forward to the rendered element.
+
+Requires `<Script events />` (plus `beacon` if the event navigates away, e.g. an external link or download).
+
+```astro
+<Event name="file.download" value="resume.pdf" as="a" href="/resume.pdf">
+  Download resume
+</Event>
+
+<Event name="nav.menu.open">Menu</Event>
+```
+
+Event names use Tinylytics' `category.action` format.
+
+| Prop    | Type                                      | Notes                                                |
+| ------- | ----------------------------------------- | ---------------------------------------------------- |
+| `name`  | `string`                                  | Required. The event name.                            |
+| `value` | `string`                                  | Optional. Stored as `event_properties["value"]`.     |
+| `as`    | `"a" \| "button" \| "div" \| "span"`      | Override the inferred tag.                           |
+
+### `<Pixel>`
+
+Renders a 1×1 tracking image for RSS feeds, HTML email, and other no-JavaScript contexts. A hit is registered when the image is fetched.
+
+```astro
+<Pixel embedCode="YOUR_EMBED_CODE" path="/posts/hello" />
+```
+
+| Prop        | Type     | Notes                                                                              |
+| ----------- | -------- | ---------------------------------------------------------------------------------- |
+| `embedCode` | `string` | Required.                                                                          |
+| `path`      | `string` | Optional. Path to attribute the hit to. A leading `/` is added if missing.         |
+
+### `<KudosButton>`
+
+Opinionated wrapper around `<Kudos>` with a configurable icon, label, count threshold, and suffix template that reveals a "— and so do N others" phrase once the count exceeds the threshold.
 
 ```astro
 ---
-import KudosButton from "@tylerbu/astro-tinylytics/KudosButton.astro";
-import "@tylerbu/astro-tinylytics/styles.css"; // optional: opt-in default styles
+import { KudosButton } from "astro-tinylytics";
+import "astro-tinylytics/styles.css"; // optional: opt-in default styles
 ---
 <KudosButton path="/my-article-slug" />
 ```
@@ -62,36 +179,71 @@ Customize:
 />
 ```
 
-Props:
+| Prop             | Type                | Default                        | Notes                                                                 |
+| ---------------- | ------------------- | ------------------------------ | --------------------------------------------------------------------- |
+| `path`           | `string`            | —                              | Required. Pins kudos to a canonical path.                             |
+| `label`          | `string`            | `"I like this"`                | Rendered as a text label and the button's `aria-label`.               |
+| `countThreshold` | `number`            | `10`                           | The suffix is hidden unless the count is strictly greater.            |
+| `suffixTemplate` | `string`            | `"— and so do {count} others"` | `{count}` is replaced with the live count.                            |
+| `icon`           | `string`            | `"🚀"`                          | Rendered via a CSS `::before` pseudo-element.                         |
+| `as`             | `"div" \| "span"`   | `"div"`                        | Wrapper element.                                                      |
+| `class`          | `string`            | —                              | Extra class applied to the wrapper.                                   |
 
-| Prop             | Type                | Default                           | Notes                                                                 |
-| ---------------- | ------------------- | --------------------------------- | --------------------------------------------------------------------- |
-| `path`           | `string`            | —                                 | Required. Pins kudos to a canonical URL path.                         |
-| `label`          | `string`            | `"I like this"`                   | Rendered as a text label and as the button's `aria-label`.            |
-| `countThreshold` | `number`            | `10`                              | The suffix is hidden unless the kudos count is strictly greater.      |
-| `suffixTemplate` | `string`            | `"— and so do {count} others"`    | `{count}` is replaced with the live count.                            |
-| `icon`           | `string`            | `"🚀"`                             | Rendered via CSS `::before` on the button.                            |
-| `as`             | `"div" \| "span"`   | `"div"`                           | Wrapper element.                                                      |
-| `class`          | `string`            | —                                 | Extra class applied to the wrapper.                                   |
+Requires the Tinylytics script to be loaded with `kudos="custom"`, which makes the embed inject only the count (a number) into the button. A small observer in the component strips the count out of the button and renders it into the suffix once it clears the threshold.
 
-The button expects the Tinylytics embed script to be loaded with `?kudos=custom`, which makes it inject only the count (a number) into the button. A small observer in the component strips the count out of the button and renders it into the suffix once it clears the threshold.
+### `<Tinylytics>` (convenience wrapper)
 
-## Theming
+Higher-level wrapper for the common "analytics OR webmention endpoint" setup. Renders either the embed `<script>` (with optional `kudos` / `hits` flags) **or** the `<link rel="webmention">` — they're typed as mutually exclusive, so call it twice if you need both. For finer control (uptime, countries, events, etc.), use `<Script>` directly.
+
+Imported via subpath (not the barrel):
+
+```astro
+---
+import Tinylytics from "astro-tinylytics/Tinylytics.astro";
+---
+<head>
+  <Tinylytics embedCode="YOUR_EMBED_CODE" webmention />
+  <Tinylytics embedCode="YOUR_EMBED_CODE" kudos="custom" hits />
+</head>
+```
+
+| Prop         | Type                      | Default | Notes                                                              |
+| ------------ | ------------------------- | ------- | ------------------------------------------------------------------ |
+| `embedCode`  | `string`                  | —       | Required.                                                          |
+| `kudos`      | `boolean \| "custom"`     | `false` | `true` → `?kudos`, `"custom"` → `?kudos=custom`.                   |
+| `hits`       | `boolean \| "unique"`     | `false` | `true` → `?hits`, `"unique"` → `?hits=unique`.                     |
+| `webmention` | `true`                    | —       | Mutually exclusive with `kudos` / `hits`.                          |
+
+## URL helpers
+
+For consumers that build Tinylytics URLs directly (e.g. for feed generation):
+
+```ts
+import { buildScriptUrl, buildPixelUrl } from "astro-tinylytics";
+
+buildScriptUrl({ embedCode: "abc", hits: true, kudos: "custom" });
+// → "https://tinylytics.app/embed/abc.js?hits&kudos=custom"
+
+buildPixelUrl("abc", "/posts/hello");
+// → "https://tinylytics.app/pixel/abc.gif?path=%2Fposts%2Fhello"
+```
+
+## Theming `<KudosButton>`
 
 Importing `styles.css` opts into the default look. Override any of these CSS variables at a higher scope to restyle without rewriting the ruleset:
 
-| Variable                       | Default                  |
-| ------------------------------ | ------------------------ |
-| `--tlt-kudos-fg`               | `inherit`                |
-| `--tlt-kudos-bg`               | `transparent`            |
-| `--tlt-kudos-border`           | `1px solid currentColor` |
-| `--tlt-kudos-radius`           | `4px`                    |
-| `--tlt-kudos-padding`          | `4px 10px`               |
-| `--tlt-kudos-icon`             | `"🚀"`                    |
-| `--tlt-kudos-hover-bg`         | `currentColor`           |
-| `--tlt-kudos-hover-fg`         | `white`                  |
-| `--tlt-kudos-hover-border`     | `currentColor`           |
-| `--tlt-kudos-muted`            | `inherit`                |
+| Variable                   | Default                  |
+| -------------------------- | ------------------------ |
+| `--tlt-kudos-fg`           | `inherit`                |
+| `--tlt-kudos-bg`           | `transparent`            |
+| `--tlt-kudos-border`       | `1px solid currentColor` |
+| `--tlt-kudos-radius`       | `4px`                    |
+| `--tlt-kudos-padding`      | `4px 10px`               |
+| `--tlt-kudos-icon`         | `"🚀"`                    |
+| `--tlt-kudos-hover-bg`     | `currentColor`           |
+| `--tlt-kudos-hover-fg`     | `white`                  |
+| `--tlt-kudos-hover-border` | `currentColor`           |
+| `--tlt-kudos-muted`        | `inherit`                |
 
 The `icon` prop writes `--tlt-kudos-icon` as an inline style on each button, so per-instance icons override the global value.
 
@@ -103,19 +255,21 @@ Skip `styles.css` entirely and style the class hooks yourself if you want full c
 - `.tinylytics-kudos-suffix` — the "and so do N others" container (set `hidden` below the threshold)
 - `.tinylytics-kudos-count` — the count span inside the suffix
 
-## Starlight note
+## Starlight
 
-Starlight lets you override the `<head>` via component overrides. Create a `Head.astro` that spreads the default plus your Tinylytics tags:
+Starlight supports `<head>` overrides via component slots. Create a `Head.astro`:
 
 ```astro
 ---
 // src/components/Head.astro
 import Default from "@astrojs/starlight/components/Head.astro";
-import Tinylytics from "@tylerbu/astro-tinylytics/Tinylytics.astro";
+import { Script } from "astro-tinylytics";
+
+const embedCode = import.meta.env.PUBLIC_TINYLYTICS;
 ---
 <Default><slot /></Default>
-<Tinylytics embedCode="YOUR_EMBED_CODE" webmention />
-<Tinylytics embedCode="YOUR_EMBED_CODE" kudos="custom" hits />
+<link rel="webmention" href={`https://tinylytics.app/webmention/${embedCode}`} />
+<Script embedCode={embedCode} hits kudos="custom" events beacon />
 ```
 
 Then register it in `astro.config.ts`:
@@ -127,10 +281,6 @@ starlight({
   },
 });
 ```
-
-## FAQ
-
-**Why two `Tinylytics` calls instead of one?** The `webmention` variant is typed as mutually exclusive with `kudos`/`hits` — the analytics script and the webmention `<link>` are independent features and intermixing them in a single call obscured that. Passing `webmention` alongside `kudos` is a type error.
 
 ## License
 

--- a/packages/astro-tinylytics/package.json
+++ b/packages/astro-tinylytics/package.json
@@ -1,17 +1,17 @@
 {
-	"name": "@tylerbu/astro-tinylytics",
+	"name": "astro-tinylytics",
 	"version": "0.1.0",
 	"description": "Astro components for Tinylytics analytics, kudos buttons, and webmentions.",
 	"keywords": [
 		"astro",
 		"astro-component",
-		"tinylytics",
-		"webmention",
-		"kudos",
 		"indieweb",
-		"analytics"
+		"analytics",
+		"kudos",
+		"tinylytics",
+		"webmention"
 	],
-	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/astro-tinylytics#tylerbuastro-tinylytics",
+	"homepage": "https://github.com/tylerbutler/tools-monorepo/tree/main/packages/astro-tinylytics#astro-tinylytics",
 	"bugs": "https://github.com/tylerbutler/tools-monorepo/issues",
 	"repository": {
 		"type": "git",
@@ -25,44 +25,48 @@
 	],
 	"type": "module",
 	"exports": {
-		"./Tinylytics.astro": "./src/Tinylytics.astro",
+		".": "./src/index.ts",
 		"./KudosButton.astro": "./src/KudosButton.astro",
 		"./styles.css": "./src/styles.css",
+		"./Tinylytics.astro": "./src/Tinylytics.astro",
 		"./package.json": "./package.json"
 	},
 	"files": [
-		"src",
 		"CHANGELOG.md",
 		"LICENSE",
-		"README.md"
+		"README.md",
+		"src"
 	],
 	"scripts": {
-		"check": "pnpm check:format && pnpm check:astro",
 		"check:astro": "astro check",
-		"check:format": "biome check . --linter-enabled=false",
 		"clean": "rimraf *.tsbuildinfo *.done.build.log .astro",
 		"format": "biome check . --linter-enabled=false --write",
 		"lint": "biome lint .",
 		"lint:fix": "biome lint . --write",
-		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs"
+		"release:license": "generate-license-file -c ../../.generatelicensefile.cjs",
+		"test:coverage": "vitest run --coverage",
+		"test:vitest": "vitest run"
 	},
 	"devDependencies": {
 		"@astrojs/check": "^0.9.6",
 		"@biomejs/biome": "2.3.8",
+		"@vitest/coverage-v8": "^4.0.18",
 		"astro": "^5.17.1",
 		"generate-license-file": "^4.1.1",
 		"rimraf": "^6.1.2",
 		"sort-package-json": "*",
-		"typescript": "~5.9.3"
+		"typescript": "~5.9.3",
+		"vitest": "^4.0.18"
 	},
 	"peerDependencies": {
-		"astro": "^5.0.0"
+		"astro": ">=4.0.0"
 	},
 	"engines": {
 		"node": ">=18.0.0"
 	},
 	"nx": {
 		"targets": {
+			"build": {},
 			"ci": {}
 		}
 	}

--- a/packages/astro-tinylytics/package.json
+++ b/packages/astro-tinylytics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "astro-tinylytics",
-	"version": "0.1.0",
+	"version": "0.0.1",
 	"description": "Astro components for Tinylytics analytics, kudos buttons, and webmentions.",
 	"keywords": [
 		"astro",

--- a/packages/astro-tinylytics/src/Countries.astro
+++ b/packages/astro-tinylytics/src/Countries.astro
@@ -1,4 +1,7 @@
 ---
+
+
+
 /**
  * Tinylytics visitor countries widget — renders emoji flags of countries
  * that have visited the site, alphabetically. Requires the script to be

--- a/packages/astro-tinylytics/src/Countries.astro
+++ b/packages/astro-tinylytics/src/Countries.astro
@@ -6,11 +6,9 @@
  *
  * @see https://tinylytics.app/docs/showing_countries
  */
-export interface Props {
-  as?: keyof HTMLElementTagNameMap;
-  class?: string;
-  ignore?: boolean;
-}
+import type { WidgetProps } from "./types.ts";
+
+export type Props = WidgetProps;
 
 const { as: Tag = "span", class: className, ignore = false } = Astro.props;
 ---

--- a/packages/astro-tinylytics/src/Countries.astro
+++ b/packages/astro-tinylytics/src/Countries.astro
@@ -1,7 +1,5 @@
 ---
 
-
-
 /**
  * Tinylytics visitor countries widget — renders emoji flags of countries
  * that have visited the site, alphabetically. Requires the script to be

--- a/packages/astro-tinylytics/src/Countries.astro
+++ b/packages/astro-tinylytics/src/Countries.astro
@@ -1,0 +1,21 @@
+---
+/**
+ * Tinylytics visitor countries widget — renders emoji flags of countries
+ * that have visited the site, alphabetically. Requires the script to be
+ * loaded with `countries`.
+ *
+ * @see https://tinylytics.app/docs/showing_countries
+ */
+export interface Props {
+  as?: keyof HTMLElementTagNameMap;
+  class?: string;
+  ignore?: boolean;
+}
+
+const { as: Tag = "span", class: className, ignore = false } = Astro.props;
+---
+
+<Tag
+  class:list={["tinylytics_countries", className]}
+  data-ignore={ignore ? "true" : undefined}
+><slot /></Tag>

--- a/packages/astro-tinylytics/src/Event.astro
+++ b/packages/astro-tinylytics/src/Event.astro
@@ -1,4 +1,7 @@
 ---
+
+
+
 /**
  * Wrap any element with Tinylytics event-tracking data attributes. Requires
  * the script to be loaded with `events` (and ideally `beacon` for links

--- a/packages/astro-tinylytics/src/Event.astro
+++ b/packages/astro-tinylytics/src/Event.astro
@@ -14,18 +14,13 @@
  *
  * @see https://tinylytics.app/docs/event_tracking
  */
+import type { EventProps } from "./types.ts";
+
 type AnchorAttrs = astroHTML.JSX.AnchorHTMLAttributes;
 type ButtonAttrs = astroHTML.JSX.ButtonHTMLAttributes;
 type DivAttrs = astroHTML.JSX.HTMLAttributes;
 
-export type Props = (AnchorAttrs | ButtonAttrs | DivAttrs) & {
-  /** Event name (`category.action`). */
-  name: string;
-  /** Optional event value (stored as `event_properties["value"]`). */
-  value?: string;
-  /** Element to render. Defaults to `a` when `href` is present, else `button`. */
-  as?: "a" | "button" | "div" | "span";
-};
+export type Props = (AnchorAttrs | ButtonAttrs | DivAttrs) & EventProps;
 
 const { name, value, as, ...rest } = Astro.props;
 const Tag = as ?? ("href" in rest && rest.href ? "a" : "button");

--- a/packages/astro-tinylytics/src/Event.astro
+++ b/packages/astro-tinylytics/src/Event.astro
@@ -1,7 +1,5 @@
 ---
 
-
-
 /**
  * Wrap any element with Tinylytics event-tracking data attributes. Requires
  * the script to be loaded with `events` (and ideally `beacon` for links

--- a/packages/astro-tinylytics/src/Event.astro
+++ b/packages/astro-tinylytics/src/Event.astro
@@ -1,0 +1,38 @@
+---
+/**
+ * Wrap any element with Tinylytics event-tracking data attributes. Requires
+ * the script to be loaded with `events` (and ideally `beacon` for links
+ * that navigate away).
+ *
+ * Event names must use the `category.action` format. The Tinylytics script
+ * also accepts `category->action` and converts arrows to dots.
+ *
+ * @example
+ *   <Event name="file.download" value="pricing.pdf" as="a" href="/pricing.pdf">
+ *     Download pricing
+ *   </Event>
+ *
+ * @see https://tinylytics.app/docs/event_tracking
+ */
+type AnchorAttrs = astroHTML.JSX.AnchorHTMLAttributes;
+type ButtonAttrs = astroHTML.JSX.ButtonHTMLAttributes;
+type DivAttrs = astroHTML.JSX.HTMLAttributes;
+
+export type Props = (AnchorAttrs | ButtonAttrs | DivAttrs) & {
+  /** Event name (`category.action`). */
+  name: string;
+  /** Optional event value (stored as `event_properties["value"]`). */
+  value?: string;
+  /** Element to render. Defaults to `a` when `href` is present, else `button`. */
+  as?: "a" | "button" | "div" | "span";
+};
+
+const { name, value, as, ...rest } = Astro.props;
+const Tag = as ?? ("href" in rest && rest.href ? "a" : "button");
+---
+
+<Tag
+  {...rest}
+  data-tinylytics-event={name}
+  data-tinylytics-event-value={value}
+><slot /></Tag>

--- a/packages/astro-tinylytics/src/Hits.astro
+++ b/packages/astro-tinylytics/src/Hits.astro
@@ -1,7 +1,5 @@
 ---
 
-
-
 /**
  * Tinylytics hit counter widget. Requires the script to be loaded with
  * `hits` (or `hits="unique"`).

--- a/packages/astro-tinylytics/src/Hits.astro
+++ b/packages/astro-tinylytics/src/Hits.astro
@@ -5,14 +5,9 @@
  *
  * @see https://tinylytics.app/docs/show_hit_counter
  */
-export interface Props {
-  /** HTML element to render. Defaults to `span`. */
-  as?: keyof HTMLElementTagNameMap;
-  /** Optional class name(s) to append. */
-  class?: string;
-  /** Ignore this widget instance (sets `data-ignore="true"`). */
-  ignore?: boolean;
-}
+import type { WidgetProps } from "./types.ts";
+
+export type Props = WidgetProps;
 
 const { as: Tag = "span", class: className, ignore = false } = Astro.props;
 ---

--- a/packages/astro-tinylytics/src/Hits.astro
+++ b/packages/astro-tinylytics/src/Hits.astro
@@ -1,4 +1,7 @@
 ---
+
+
+
 /**
  * Tinylytics hit counter widget. Requires the script to be loaded with
  * `hits` (or `hits="unique"`).

--- a/packages/astro-tinylytics/src/Hits.astro
+++ b/packages/astro-tinylytics/src/Hits.astro
@@ -1,0 +1,23 @@
+---
+/**
+ * Tinylytics hit counter widget. Requires the script to be loaded with
+ * `hits` (or `hits="unique"`).
+ *
+ * @see https://tinylytics.app/docs/show_hit_counter
+ */
+export interface Props {
+  /** HTML element to render. Defaults to `span`. */
+  as?: keyof HTMLElementTagNameMap;
+  /** Optional class name(s) to append. */
+  class?: string;
+  /** Ignore this widget instance (sets `data-ignore="true"`). */
+  ignore?: boolean;
+}
+
+const { as: Tag = "span", class: className, ignore = false } = Astro.props;
+---
+
+<Tag
+  class:list={["tinylytics_hits", className]}
+  data-ignore={ignore ? "true" : undefined}
+><slot /></Tag>

--- a/packages/astro-tinylytics/src/Kudos.astro
+++ b/packages/astro-tinylytics/src/Kudos.astro
@@ -1,0 +1,41 @@
+---
+/**
+ * Tinylytics kudos (like) button. Requires the script to be loaded with
+ * `kudos` (any variant, including `kudos="custom"`).
+ *
+ * - Leave the slot empty to let Tinylytics inject the default `👋 N` content.
+ * - When `kudos="custom"` is used on the script loader, the script will
+ *   inject just the count, leaving you free to render your own visual.
+ *
+ * @see https://tinylytics.app/docs/showing_kudos
+ */
+export interface Props {
+  /**
+   * Path the kudos count is associated with. Required when multiple kudos
+   * buttons live on a single page (e.g. an index of posts). Must start
+   * with `/`.
+   */
+  path?: string;
+  /** Render kudos privately (count visible only to the site owner). */
+  private?: boolean;
+  /** Ignore clicks on this button (useful for demos). */
+  ignore?: boolean;
+  /** Optional class name(s) to append. */
+  class?: string;
+}
+
+const {
+  path,
+  private: isPrivate = false,
+  ignore = false,
+  class: className,
+} = Astro.props;
+---
+
+<button
+  type="button"
+  class:list={["tinylytics_kudos", className]}
+  data-path={path}
+  data-private={isPrivate ? "true" : undefined}
+  data-ignore={ignore ? "true" : undefined}
+><slot /></button>

--- a/packages/astro-tinylytics/src/Kudos.astro
+++ b/packages/astro-tinylytics/src/Kudos.astro
@@ -1,4 +1,7 @@
 ---
+
+
+
 /**
  * Tinylytics kudos (like) button. Requires the script to be loaded with
  * `kudos` (any variant, including `kudos="custom"`).

--- a/packages/astro-tinylytics/src/Kudos.astro
+++ b/packages/astro-tinylytics/src/Kudos.astro
@@ -9,20 +9,9 @@
  *
  * @see https://tinylytics.app/docs/showing_kudos
  */
-export interface Props {
-  /**
-   * Path the kudos count is associated with. Required when multiple kudos
-   * buttons live on a single page (e.g. an index of posts). Must start
-   * with `/`.
-   */
-  path?: string;
-  /** Render kudos privately (count visible only to the site owner). */
-  private?: boolean;
-  /** Ignore clicks on this button (useful for demos). */
-  ignore?: boolean;
-  /** Optional class name(s) to append. */
-  class?: string;
-}
+import type { KudosProps } from "./types.ts";
+
+export type Props = KudosProps;
 
 const {
   path,

--- a/packages/astro-tinylytics/src/Kudos.astro
+++ b/packages/astro-tinylytics/src/Kudos.astro
@@ -1,7 +1,5 @@
 ---
 
-
-
 /**
  * Tinylytics kudos (like) button. Requires the script to be loaded with
  * `kudos` (any variant, including `kudos="custom"`).

--- a/packages/astro-tinylytics/src/KudosButton.astro
+++ b/packages/astro-tinylytics/src/KudosButton.astro
@@ -1,7 +1,5 @@
 ---
 
-
-
 import type { KudosButtonProps } from "./types.ts";
 
 export type Props = KudosButtonProps;
@@ -15,10 +13,6 @@ const {
 	class: className,
 	as: Tag = "div",
 } = Astro.props;
-
-const wrapperClass = ["tinylytics-kudos-wrapper", className]
-	.filter(Boolean)
-	.join(" ");
 
 // JSON.stringify produces a CSS-safe quoted string (handles embedded quotes).
 const iconStyle = `--tlt-kudos-icon: ${JSON.stringify(icon)}`;
@@ -36,7 +30,10 @@ const suffixPostfix =
 		: "";
 ---
 
-<Tag class={wrapperClass} data-count-threshold={String(countThreshold)}>
+<Tag
+	class:list={["tinylytics-kudos-wrapper", className]}
+	data-count-threshold={String(countThreshold)}
+>
 	<span class="tinylytics-kudos-label">{label}</span>
 	<button
 		class="tinylytics_kudos"

--- a/packages/astro-tinylytics/src/KudosButton.astro
+++ b/packages/astro-tinylytics/src/KudosButton.astro
@@ -1,5 +1,5 @@
 ---
-interface Props {
+export interface Props {
 	path: string;
 	label?: string;
 	countThreshold?: number;

--- a/packages/astro-tinylytics/src/KudosButton.astro
+++ b/packages/astro-tinylytics/src/KudosButton.astro
@@ -1,13 +1,7 @@
 ---
-export interface Props {
-	path: string;
-	label?: string;
-	countThreshold?: number;
-	suffixTemplate?: string;
-	icon?: string;
-	class?: string;
-	as?: "div" | "span";
-}
+import type { KudosButtonProps } from "./types.ts";
+
+export type Props = KudosButtonProps;
 
 const {
 	path,

--- a/packages/astro-tinylytics/src/KudosButton.astro
+++ b/packages/astro-tinylytics/src/KudosButton.astro
@@ -1,4 +1,7 @@
 ---
+
+
+
 import type { KudosButtonProps } from "./types.ts";
 
 export type Props = KudosButtonProps;

--- a/packages/astro-tinylytics/src/Pixel.astro
+++ b/packages/astro-tinylytics/src/Pixel.astro
@@ -1,8 +1,5 @@
 ---
 
-
-
-import type { PixelProps } from "./types.ts";
 /**
  * Tinylytics tracking pixel for environments that do not support JavaScript,
  * such as RSS feeds or HTML email. Renders an invisible 1×1 GIF that
@@ -10,6 +7,7 @@ import type { PixelProps } from "./types.ts";
  *
  * @see https://tinylytics.app/docs/pixel_tracking
  */
+import type { PixelProps } from "./types.ts";
 import { buildPixelUrl } from "./urls.ts";
 
 export type Props = PixelProps;

--- a/packages/astro-tinylytics/src/Pixel.astro
+++ b/packages/astro-tinylytics/src/Pixel.astro
@@ -1,4 +1,8 @@
 ---
+
+
+
+import type { PixelProps } from "./types.ts";
 /**
  * Tinylytics tracking pixel for environments that do not support JavaScript,
  * such as RSS feeds or HTML email. Renders an invisible 1×1 GIF that
@@ -7,7 +11,6 @@
  * @see https://tinylytics.app/docs/pixel_tracking
  */
 import { buildPixelUrl } from "./urls.ts";
-import type { PixelProps } from "./types.ts";
 
 export type Props = PixelProps;
 

--- a/packages/astro-tinylytics/src/Pixel.astro
+++ b/packages/astro-tinylytics/src/Pixel.astro
@@ -7,16 +7,9 @@
  * @see https://tinylytics.app/docs/pixel_tracking
  */
 import { buildPixelUrl } from "./urls.ts";
+import type { PixelProps } from "./types.ts";
 
-export interface Props {
-  /** Your unique site embed code. */
-  embedCode: string;
-  /**
-   * Optional path to associate with this view (e.g. the post URL). Strongly
-   * recommended for per-content tracking. Leading slash is added automatically.
-   */
-  path?: string;
-}
+export type Props = PixelProps;
 
 const { embedCode, path } = Astro.props;
 const src = buildPixelUrl(embedCode, path);

--- a/packages/astro-tinylytics/src/Pixel.astro
+++ b/packages/astro-tinylytics/src/Pixel.astro
@@ -1,0 +1,33 @@
+---
+/**
+ * Tinylytics tracking pixel for environments that do not support JavaScript,
+ * such as RSS feeds or HTML email. Renders an invisible 1×1 GIF that
+ * registers a hit when fetched.
+ *
+ * @see https://tinylytics.app/docs/pixel_tracking
+ */
+import { buildPixelUrl } from "./urls.ts";
+
+export interface Props {
+  /** Your unique site embed code. */
+  embedCode: string;
+  /**
+   * Optional path to associate with this view (e.g. the post URL). Strongly
+   * recommended for per-content tracking. Leading slash is added automatically.
+   */
+  path?: string;
+}
+
+const { embedCode, path } = Astro.props;
+const src = buildPixelUrl(embedCode, path);
+---
+
+<img
+  src={src}
+  alt=""
+  width="1"
+  height="1"
+  style="width:1px;height:1px;border:0;"
+  aria-hidden="true"
+  loading="eager"
+/>

--- a/packages/astro-tinylytics/src/Script.astro
+++ b/packages/astro-tinylytics/src/Script.astro
@@ -1,0 +1,53 @@
+---
+/**
+ * Tinylytics script loader.
+ *
+ * Renders the `<script>` tag for the Tinylytics analytics embed and exposes
+ * every documented script-URL parameter as a typed prop.
+ *
+ * @see https://tinylytics.app/docs/embedding_your_script
+ */
+import { buildScriptUrl } from "./urls.ts";
+
+export interface Props {
+  /** The unique site embed code from your Tinylytics dashboard. */
+  embedCode: string;
+  /** Use the minified embed (`/min.js`). */
+  min?: boolean;
+  /** Enable SPA mode for client-side navigation tracking. */
+  spa?: boolean;
+  /** Ignore hits from this page load (useful while developing). */
+  ignore?: boolean;
+  /**
+   * Hit counter widget.
+   * `true` → `?hits`; `"unique"` → `?hits=unique` (paid plans).
+   */
+  hits?: boolean | "unique";
+  /**
+   * Kudos widget.
+   * `true` → default 👋 emoji; `"custom"` → count only;
+   * any other string → custom emoji (e.g. `"❤️"`).
+   */
+  kudos?: boolean | "custom" | string;
+  /** Uptime percentage widget (paid plans). */
+  uptime?: boolean;
+  /** Visitor country flags widget. */
+  countries?: boolean;
+  /**
+   * Webring widget.
+   * `true` → text-only; `"avatars"` → include site avatars.
+   */
+  webring?: boolean | "avatars";
+  /** Enable click event tracking via `data-tinylytics-event` attributes. */
+  events?: boolean;
+  /** Use `navigator.sendBeacon` for events (better for unload navigations). */
+  beacon?: boolean;
+  /** Add `defer` to the script tag. Defaults to `true`. */
+  defer?: boolean;
+}
+
+const { defer = true, ...rest } = Astro.props;
+const scriptSrc = buildScriptUrl(rest);
+---
+
+{defer ? <script src={scriptSrc} defer is:inline /> : <script src={scriptSrc} is:inline />}

--- a/packages/astro-tinylytics/src/Script.astro
+++ b/packages/astro-tinylytics/src/Script.astro
@@ -8,43 +8,9 @@
  * @see https://tinylytics.app/docs/embedding_your_script
  */
 import { buildScriptUrl } from "./urls.ts";
+import type { ScriptProps } from "./types.ts";
 
-export interface Props {
-  /** The unique site embed code from your Tinylytics dashboard. */
-  embedCode: string;
-  /** Use the minified embed (`/min.js`). */
-  min?: boolean;
-  /** Enable SPA mode for client-side navigation tracking. */
-  spa?: boolean;
-  /** Ignore hits from this page load (useful while developing). */
-  ignore?: boolean;
-  /**
-   * Hit counter widget.
-   * `true` → `?hits`; `"unique"` → `?hits=unique` (paid plans).
-   */
-  hits?: boolean | "unique";
-  /**
-   * Kudos widget.
-   * `true` → default 👋 emoji; `"custom"` → count only;
-   * any other string → custom emoji (e.g. `"❤️"`).
-   */
-  kudos?: boolean | "custom" | string;
-  /** Uptime percentage widget (paid plans). */
-  uptime?: boolean;
-  /** Visitor country flags widget. */
-  countries?: boolean;
-  /**
-   * Webring widget.
-   * `true` → text-only; `"avatars"` → include site avatars.
-   */
-  webring?: boolean | "avatars";
-  /** Enable click event tracking via `data-tinylytics-event` attributes. */
-  events?: boolean;
-  /** Use `navigator.sendBeacon` for events (better for unload navigations). */
-  beacon?: boolean;
-  /** Add `defer` to the script tag. Defaults to `true`. */
-  defer?: boolean;
-}
+export type Props = ScriptProps;
 
 const { defer = true, ...rest } = Astro.props;
 const scriptSrc = buildScriptUrl(rest);

--- a/packages/astro-tinylytics/src/Script.astro
+++ b/packages/astro-tinylytics/src/Script.astro
@@ -1,4 +1,8 @@
 ---
+
+
+
+import type { ScriptProps } from "./types.ts";
 /**
  * Tinylytics script loader.
  *
@@ -8,7 +12,6 @@
  * @see https://tinylytics.app/docs/embedding_your_script
  */
 import { buildScriptUrl } from "./urls.ts";
-import type { ScriptProps } from "./types.ts";
 
 export type Props = ScriptProps;
 

--- a/packages/astro-tinylytics/src/Script.astro
+++ b/packages/astro-tinylytics/src/Script.astro
@@ -1,8 +1,5 @@
 ---
 
-
-
-import type { ScriptProps } from "./types.ts";
 /**
  * Tinylytics script loader.
  *
@@ -11,6 +8,7 @@ import type { ScriptProps } from "./types.ts";
  *
  * @see https://tinylytics.app/docs/embedding_your_script
  */
+import type { ScriptProps } from "./types.ts";
 import { buildScriptUrl } from "./urls.ts";
 
 export type Props = ScriptProps;

--- a/packages/astro-tinylytics/src/Tinylytics.astro
+++ b/packages/astro-tinylytics/src/Tinylytics.astro
@@ -1,6 +1,6 @@
 ---
 
-
+import { buildScriptUrl } from "./urls.ts";
 
 type Props =
 	| { embedCode: string; webmention: true; kudos?: never; hits?: never }
@@ -12,28 +12,10 @@ type Props =
 	  };
 
 const props = Astro.props;
-const { embedCode } = props;
-
-let webmentionHref: string | null = null;
-let scriptSrc: string | null = null;
-
-if (props.webmention === true) {
-	webmentionHref = `https://tinylytics.app/webmention/${embedCode}`;
-} else {
-	const flags: string[] = [];
-	if (props.kudos === "custom") {
-		flags.push("kudos=custom");
-	} else if (props.kudos === true) {
-		flags.push("kudos");
-	}
-	if (props.hits === "unique") {
-		flags.push("hits=unique");
-	} else if (props.hits === true) {
-		flags.push("hits");
-	}
-	const query = flags.length > 0 ? `?${flags.join("&")}` : "";
-	scriptSrc = `https://tinylytics.app/embed/${embedCode}.js${query}`;
-}
+const webmentionHref = props.webmention
+	? `https://tinylytics.app/webmention/${props.embedCode}`
+	: null;
+const scriptSrc = props.webmention ? null : buildScriptUrl(props);
 ---
 
 {webmentionHref && <link rel="webmention" href={webmentionHref} />}

--- a/packages/astro-tinylytics/src/Tinylytics.astro
+++ b/packages/astro-tinylytics/src/Tinylytics.astro
@@ -1,4 +1,7 @@
 ---
+
+
+
 type Props =
 	| { embedCode: string; webmention: true; kudos?: never; hits?: never }
 	| {

--- a/packages/astro-tinylytics/src/Uptime.astro
+++ b/packages/astro-tinylytics/src/Uptime.astro
@@ -7,11 +7,9 @@
  *
  * @see https://tinylytics.app/docs/showing_uptime
  */
-export interface Props {
-  as?: keyof HTMLElementTagNameMap;
-  class?: string;
-  ignore?: boolean;
-}
+import type { WidgetProps } from "./types.ts";
+
+export type Props = WidgetProps;
 
 const { as: Tag = "span", class: className, ignore = false } = Astro.props;
 ---

--- a/packages/astro-tinylytics/src/Uptime.astro
+++ b/packages/astro-tinylytics/src/Uptime.astro
@@ -1,7 +1,5 @@
 ---
 
-
-
 /**
  * Tinylytics uptime widget. Requires the script to be loaded with `uptime`
  * and uptime monitoring enabled on a paid plan.

--- a/packages/astro-tinylytics/src/Uptime.astro
+++ b/packages/astro-tinylytics/src/Uptime.astro
@@ -1,0 +1,22 @@
+---
+/**
+ * Tinylytics uptime widget. Requires the script to be loaded with `uptime`
+ * and uptime monitoring enabled on a paid plan.
+ *
+ * Only one uptime element should appear per page.
+ *
+ * @see https://tinylytics.app/docs/showing_uptime
+ */
+export interface Props {
+  as?: keyof HTMLElementTagNameMap;
+  class?: string;
+  ignore?: boolean;
+}
+
+const { as: Tag = "span", class: className, ignore = false } = Astro.props;
+---
+
+<Tag
+  class:list={["tinylytics_uptime", className]}
+  data-ignore={ignore ? "true" : undefined}
+><slot /></Tag>

--- a/packages/astro-tinylytics/src/Uptime.astro
+++ b/packages/astro-tinylytics/src/Uptime.astro
@@ -1,4 +1,7 @@
 ---
+
+
+
 /**
  * Tinylytics uptime widget. Requires the script to be loaded with `uptime`
  * and uptime monitoring enabled on a paid plan.

--- a/packages/astro-tinylytics/src/Webring.astro
+++ b/packages/astro-tinylytics/src/Webring.astro
@@ -1,4 +1,7 @@
 ---
+
+
+
 /**
  * Tinylytics webring link — renders a link that the embed script populates
  * with a random member of the Tinylytics webring on page load. Requires the

--- a/packages/astro-tinylytics/src/Webring.astro
+++ b/packages/astro-tinylytics/src/Webring.astro
@@ -1,0 +1,62 @@
+---
+/**
+ * Tinylytics webring link — renders a link that the embed script populates
+ * with a random member of the Tinylytics webring on page load. Requires the
+ * script to be loaded with `webring` (or `webring="avatars"`).
+ *
+ * Use the `avatar` prop to render the optional avatar image; the script
+ * fills in `src`/`srcset` and removes `display: none` once loaded.
+ *
+ * The default slot lets you provide your own label/markup. If empty,
+ * Tinylytics will leave whatever you render in place.
+ *
+ * @see https://tinylytics.app/docs/showing_webring
+ */
+export interface Props {
+  /** Render the avatar `<img>` placeholder. Requires `webring="avatars"` on the script. */
+  avatar?: boolean;
+  /** Position of the avatar relative to the slot content. */
+  avatarPosition?: "before" | "after";
+  /** Open the link in a new tab. Defaults to `true`. */
+  newTab?: boolean;
+  /** Optional class name(s) to append. */
+  class?: string;
+  /** Alt text for the avatar image (defaults to empty + aria-hidden). */
+  avatarAlt?: string;
+}
+
+const {
+  avatar = false,
+  avatarPosition = "before",
+  newTab = true,
+  class: className,
+  avatarAlt = "",
+} = Astro.props;
+---
+
+<a
+  href="#"
+  target={newTab ? "_blank" : undefined}
+  rel={newTab ? "noopener" : undefined}
+  class:list={["tinylytics_webring", className]}
+>
+  {avatar && avatarPosition === "before" && (
+    <img
+      class="tinylytics_webring_avatar"
+      src=""
+      style="display: none"
+      alt={avatarAlt}
+      aria-hidden={avatarAlt === "" ? "true" : undefined}
+    />
+  )}
+  <slot />
+  {avatar && avatarPosition === "after" && (
+    <img
+      class="tinylytics_webring_avatar"
+      src=""
+      style="display: none"
+      alt={avatarAlt}
+      aria-hidden={avatarAlt === "" ? "true" : undefined}
+    />
+  )}
+</a>

--- a/packages/astro-tinylytics/src/Webring.astro
+++ b/packages/astro-tinylytics/src/Webring.astro
@@ -12,18 +12,9 @@
  *
  * @see https://tinylytics.app/docs/showing_webring
  */
-export interface Props {
-  /** Render the avatar `<img>` placeholder. Requires `webring="avatars"` on the script. */
-  avatar?: boolean;
-  /** Position of the avatar relative to the slot content. */
-  avatarPosition?: "before" | "after";
-  /** Open the link in a new tab. Defaults to `true`. */
-  newTab?: boolean;
-  /** Optional class name(s) to append. */
-  class?: string;
-  /** Alt text for the avatar image (defaults to empty + aria-hidden). */
-  avatarAlt?: string;
-}
+import type { WebringProps } from "./types.ts";
+
+export type Props = WebringProps;
 
 const {
   avatar = false,

--- a/packages/astro-tinylytics/src/Webring.astro
+++ b/packages/astro-tinylytics/src/Webring.astro
@@ -1,7 +1,5 @@
 ---
 
-
-
 /**
  * Tinylytics webring link — renders a link that the embed script populates
  * with a random member of the Tinylytics webring on page load. Requires the

--- a/packages/astro-tinylytics/src/index.ts
+++ b/packages/astro-tinylytics/src/index.ts
@@ -27,10 +27,12 @@ export { default as Countries } from "./Countries.astro";
 export { default as Event } from "./Event.astro";
 export { default as Hits } from "./Hits.astro";
 export { default as Kudos } from "./Kudos.astro";
+export { default as KudosButton } from "./KudosButton.astro";
 export { default as Pixel } from "./Pixel.astro";
 export { default as Script } from "./Script.astro";
 export type {
 	EventProps,
+	KudosButtonProps,
 	KudosProps,
 	PixelProps,
 	ScriptProps,

--- a/packages/astro-tinylytics/src/index.ts
+++ b/packages/astro-tinylytics/src/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Astro components for Tinylytics — a privacy-first analytics service.
+ *
+ * The package mirrors every script parameter and widget element documented at
+ * https://tinylytics.app/docs and is designed to drop into any Astro site
+ * (including Starlight). Components are unstyled by default; consumers
+ * provide their own CSS.
+ *
+ * Typical setup (e.g. in `BaseLayout.astro` or a Starlight `Head` override):
+ *
+ *   <Script embedCode="YOUR_CODE" hits kudos events beacon />
+ *
+ * Then drop widgets where you want them:
+ *
+ *   <Hits />              ← lifetime hit counter
+ *   <Kudos path="/post" /> ← like button for the current post
+ *   <Uptime />            ← uptime percentage
+ *   <Countries />         ← visitor country flags
+ *   <Webring avatar />    ← random webring member
+ *
+ * For RSS / email contexts use the no-JS pixel:
+ *
+ *   <Pixel embedCode="YOUR_CODE" path="/posts/hello" />
+ */
+
+export { default as Countries } from "./Countries.astro";
+export { default as Event } from "./Event.astro";
+export { default as Hits } from "./Hits.astro";
+export { default as Kudos } from "./Kudos.astro";
+export { default as Pixel } from "./Pixel.astro";
+export { default as Script } from "./Script.astro";
+export type {
+	EventProps,
+	KudosProps,
+	PixelProps,
+	ScriptProps,
+	WebringProps,
+	WidgetProps,
+} from "./types.ts";
+export { default as Uptime } from "./Uptime.astro";
+export { buildPixelUrl, buildScriptUrl } from "./urls.ts";
+export { default as Webring } from "./Webring.astro";

--- a/packages/astro-tinylytics/src/types.ts
+++ b/packages/astro-tinylytics/src/types.ts
@@ -11,7 +11,7 @@ export interface ScriptProps {
 	spa?: boolean;
 	ignore?: boolean;
 	hits?: boolean | "unique";
-	kudos?: boolean | "custom" | string;
+	kudos?: boolean | "custom" | (string & {});
 	uptime?: boolean;
 	countries?: boolean;
 	webring?: boolean | "avatars";

--- a/packages/astro-tinylytics/src/types.ts
+++ b/packages/astro-tinylytics/src/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared prop types for the tinylytics Astro components. Astro `.astro`
+ * files cannot re-export their `Props` interface through a barrel `index.ts`
+ * (only the default component export is forwarded), so the types live here
+ * for consumers that need them.
+ */
+
+export interface ScriptProps {
+	embedCode: string;
+	min?: boolean;
+	spa?: boolean;
+	ignore?: boolean;
+	hits?: boolean | "unique";
+	kudos?: boolean | "custom" | string;
+	uptime?: boolean;
+	countries?: boolean;
+	webring?: boolean | "avatars";
+	events?: boolean;
+	beacon?: boolean;
+	defer?: boolean;
+}
+
+export interface WidgetProps {
+	/** HTML element to render. */
+	as?: keyof HTMLElementTagNameMap;
+	/** Optional class name(s) to append. */
+	class?: string;
+	/** Sets `data-ignore="true"` so this instance is excluded from tracking. */
+	ignore?: boolean;
+}
+
+export interface KudosProps {
+	/** Path the kudos count is associated with. Required for multi-button pages. */
+	path?: string;
+	/** Render kudos privately (count visible only to the site owner). */
+	private?: boolean;
+	ignore?: boolean;
+	class?: string;
+}
+
+export interface WebringProps {
+	avatar?: boolean;
+	avatarPosition?: "before" | "after";
+	newTab?: boolean;
+	class?: string;
+	avatarAlt?: string;
+}
+
+export interface PixelProps {
+	embedCode: string;
+	path?: string;
+}
+
+export interface EventProps {
+	/** Event name in `category.action` format. */
+	name: string;
+	/** Optional event value stored as `event_properties["value"]`. */
+	value?: string;
+	/** Element to render. Defaults to `a` when `href` is present, else `button`. */
+	as?: "a" | "button" | "div" | "span";
+}

--- a/packages/astro-tinylytics/src/types.ts
+++ b/packages/astro-tinylytics/src/types.ts
@@ -51,6 +51,16 @@ export interface PixelProps {
 	path?: string;
 }
 
+export interface KudosButtonProps {
+	path: string;
+	label?: string;
+	countThreshold?: number;
+	suffixTemplate?: string;
+	icon?: string;
+	class?: string;
+	as?: "div" | "span";
+}
+
 export interface EventProps {
 	/** Event name in `category.action` format. */
 	name: string;

--- a/packages/astro-tinylytics/src/urls.ts
+++ b/packages/astro-tinylytics/src/urls.ts
@@ -2,7 +2,6 @@ import type { ScriptProps } from "./types.ts";
 
 /**
  * Builds the Tinylytics embed script URL from ScriptProps.
- * Extracted for testability.
  */
 export function buildScriptUrl(props: ScriptProps): string {
 	const {
@@ -68,7 +67,6 @@ export function buildScriptUrl(props: ScriptProps): string {
 
 /**
  * Builds the Tinylytics pixel tracking URL.
- * Extracted for testability.
  */
 export function buildPixelUrl(embedCode: string, path?: string): string {
 	let src = `https://tinylytics.app/pixel/${embedCode}.gif`;

--- a/packages/astro-tinylytics/src/urls.ts
+++ b/packages/astro-tinylytics/src/urls.ts
@@ -21,23 +21,45 @@ export function buildScriptUrl(props: ScriptProps): string {
 
 	const flags: string[] = [];
 
-	if (hits === "unique") flags.push("hits=unique");
-	else if (hits === true) flags.push("hits");
+	if (hits === "unique") {
+		flags.push("hits=unique");
+	} else if (hits === true) {
+		flags.push("hits");
+	}
 
-	if (kudos === true) flags.push("kudos");
-	else if (kudos === "custom") flags.push("kudos=custom");
-	else if (typeof kudos === "string") flags.push(`kudos=${kudos}`);
+	if (kudos === true) {
+		flags.push("kudos");
+	} else if (kudos === "custom") {
+		flags.push("kudos=custom");
+	} else if (typeof kudos === "string") {
+		flags.push(`kudos=${kudos}`);
+	}
 
-	if (uptime) flags.push("uptime");
-	if (countries) flags.push("countries");
+	if (uptime) {
+		flags.push("uptime");
+	}
+	if (countries) {
+		flags.push("countries");
+	}
 
-	if (webring === "avatars") flags.push("webring=avatars");
-	else if (webring) flags.push("webring");
+	if (webring === "avatars") {
+		flags.push("webring=avatars");
+	} else if (webring) {
+		flags.push("webring");
+	}
 
-	if (events) flags.push("events");
-	if (beacon) flags.push("beacon");
-	if (spa) flags.push("spa");
-	if (ignore) flags.push("ignore");
+	if (events) {
+		flags.push("events");
+	}
+	if (beacon) {
+		flags.push("beacon");
+	}
+	if (spa) {
+		flags.push("spa");
+	}
+	if (ignore) {
+		flags.push("ignore");
+	}
 
 	const path = min ? `${embedCode}/min.js` : `${embedCode}.js`;
 	const query = flags.length > 0 ? `?${flags.join("&")}` : "";

--- a/packages/astro-tinylytics/src/urls.ts
+++ b/packages/astro-tinylytics/src/urls.ts
@@ -1,0 +1,58 @@
+import type { ScriptProps } from "./types.ts";
+
+/**
+ * Builds the Tinylytics embed script URL from ScriptProps.
+ * Extracted for testability.
+ */
+export function buildScriptUrl(props: ScriptProps): string {
+	const {
+		embedCode,
+		min = false,
+		spa = false,
+		ignore = false,
+		hits,
+		kudos,
+		uptime = false,
+		countries = false,
+		webring,
+		events = false,
+		beacon = false,
+	} = props;
+
+	const flags: string[] = [];
+
+	if (hits === "unique") flags.push("hits=unique");
+	else if (hits === true) flags.push("hits");
+
+	if (kudos === true) flags.push("kudos");
+	else if (kudos === "custom") flags.push("kudos=custom");
+	else if (typeof kudos === "string") flags.push(`kudos=${kudos}`);
+
+	if (uptime) flags.push("uptime");
+	if (countries) flags.push("countries");
+
+	if (webring === "avatars") flags.push("webring=avatars");
+	else if (webring) flags.push("webring");
+
+	if (events) flags.push("events");
+	if (beacon) flags.push("beacon");
+	if (spa) flags.push("spa");
+	if (ignore) flags.push("ignore");
+
+	const path = min ? `${embedCode}/min.js` : `${embedCode}.js`;
+	const query = flags.length > 0 ? `?${flags.join("&")}` : "";
+	return `https://tinylytics.app/embed/${path}${query}`;
+}
+
+/**
+ * Builds the Tinylytics pixel tracking URL.
+ * Extracted for testability.
+ */
+export function buildPixelUrl(embedCode: string, path?: string): string {
+	let src = `https://tinylytics.app/pixel/${embedCode}.gif`;
+	if (path) {
+		const normalized = path.startsWith("/") ? path : `/${path}`;
+		src += `?path=${encodeURIComponent(normalized)}`;
+	}
+	return src;
+}

--- a/packages/astro-tinylytics/test/components.test.ts
+++ b/packages/astro-tinylytics/test/components.test.ts
@@ -15,11 +15,12 @@ beforeAll(async () => {
 	container = await experimental_AstroContainer.create();
 });
 
+const SOURCE_FILE_RE = /\s*data-astro-source-file="[^"]*"/g;
+const SOURCE_LOC_RE = /\s*data-astro-source-loc="[^"]*"/g;
+
 /** Strip Astro dev-mode source-map attributes that contain absolute paths. */
 function clean(html: string): string {
-	return html
-		.replace(/\s*data-astro-source-file="[^"]*"/g, "")
-		.replace(/\s*data-astro-source-loc="[^"]*"/g, "");
+	return html.replace(SOURCE_FILE_RE, "").replace(SOURCE_LOC_RE, "");
 }
 
 async function render(
@@ -28,10 +29,6 @@ async function render(
 ): Promise<string> {
 	return clean(await container.renderToString(component, options));
 }
-
-// ---------------------------------------------------------------------------
-// Script
-// ---------------------------------------------------------------------------
 
 describe("Script", () => {
 	it("renders a deferred script tag by default", async () => {
@@ -75,10 +72,6 @@ describe("Script", () => {
 	});
 });
 
-// ---------------------------------------------------------------------------
-// Hits
-// ---------------------------------------------------------------------------
-
 describe("Hits", () => {
 	it("renders a span with tinylytics_hits class", async () => {
 		const html = await render(Hits);
@@ -113,10 +106,6 @@ describe("Hits", () => {
 		);
 	});
 });
-
-// ---------------------------------------------------------------------------
-// Kudos
-// ---------------------------------------------------------------------------
 
 describe("Kudos", () => {
 	it("renders a button with tinylytics_kudos class", async () => {
@@ -155,10 +144,6 @@ describe("Kudos", () => {
 	});
 });
 
-// ---------------------------------------------------------------------------
-// Countries
-// ---------------------------------------------------------------------------
-
 describe("Countries", () => {
 	it("renders a span with tinylytics_countries class", async () => {
 		const html = await render(Countries);
@@ -184,10 +169,6 @@ describe("Countries", () => {
 	});
 });
 
-// ---------------------------------------------------------------------------
-// Uptime
-// ---------------------------------------------------------------------------
-
 describe("Uptime", () => {
 	it("renders a span with tinylytics_uptime class", async () => {
 		const html = await render(Uptime);
@@ -205,10 +186,6 @@ describe("Uptime", () => {
 		);
 	});
 });
-
-// ---------------------------------------------------------------------------
-// Webring
-// ---------------------------------------------------------------------------
 
 describe("Webring", () => {
 	it("renders an anchor with tinylytics_webring class opening in a new tab", async () => {
@@ -259,10 +236,6 @@ describe("Webring", () => {
 	});
 });
 
-// ---------------------------------------------------------------------------
-// Event
-// ---------------------------------------------------------------------------
-
 describe("Event", () => {
 	it("renders a button when no href is present", async () => {
 		const html = await render(Event, {
@@ -308,10 +281,6 @@ describe("Event", () => {
 		);
 	});
 });
-
-// ---------------------------------------------------------------------------
-// Pixel
-// ---------------------------------------------------------------------------
 
 describe("Pixel", () => {
 	it("renders a 1x1 img with the embed code URL", async () => {

--- a/packages/astro-tinylytics/test/components.test.ts
+++ b/packages/astro-tinylytics/test/components.test.ts
@@ -82,7 +82,9 @@ describe("Script", () => {
 describe("Hits", () => {
 	it("renders a span with tinylytics_hits class", async () => {
 		const html = await render(Hits);
-		expect(html).toMatchInlineSnapshot(`"<span class="tinylytics_hits"></span>"`);
+		expect(html).toMatchInlineSnapshot(
+			`"<span class="tinylytics_hits"></span>"`,
+		);
 	});
 
 	it("renders slot content", async () => {
@@ -294,7 +296,11 @@ describe("Event", () => {
 
 	it("adds data-tinylytics-event-value when value is provided", async () => {
 		const html = await render(Event, {
-			props: { name: "file.download", value: "resume.pdf", href: "/resume.pdf" },
+			props: {
+				name: "file.download",
+				value: "resume.pdf",
+				href: "/resume.pdf",
+			},
 			slots: { default: "Download" },
 		});
 		expect(html).toMatchInlineSnapshot(

--- a/packages/astro-tinylytics/test/components.test.ts
+++ b/packages/astro-tinylytics/test/components.test.ts
@@ -1,0 +1,335 @@
+import { experimental_AstroContainer } from "astro/container";
+import { beforeAll, describe, expect, it } from "vitest";
+import Countries from "../src/Countries.astro";
+import Event from "../src/Event.astro";
+import Hits from "../src/Hits.astro";
+import Kudos from "../src/Kudos.astro";
+import Pixel from "../src/Pixel.astro";
+import Script from "../src/Script.astro";
+import Uptime from "../src/Uptime.astro";
+import Webring from "../src/Webring.astro";
+
+let container: experimental_AstroContainer;
+
+beforeAll(async () => {
+	container = await experimental_AstroContainer.create();
+});
+
+/** Strip Astro dev-mode source-map attributes that contain absolute paths. */
+function clean(html: string): string {
+	return html
+		.replace(/\s*data-astro-source-file="[^"]*"/g, "")
+		.replace(/\s*data-astro-source-loc="[^"]*"/g, "");
+}
+
+async function render(
+	component: Parameters<typeof container.renderToString>[0],
+	options?: Parameters<typeof container.renderToString>[1],
+): Promise<string> {
+	return clean(await container.renderToString(component, options));
+}
+
+// ---------------------------------------------------------------------------
+// Script
+// ---------------------------------------------------------------------------
+
+describe("Script", () => {
+	it("renders a deferred script tag by default", async () => {
+		const html = await render(Script, { props: { embedCode: "abc123" } });
+		expect(html).toMatchInlineSnapshot(
+			`"<script src="https://tinylytics.app/embed/abc123.js" defer></script>"`,
+		);
+	});
+
+	it("renders without defer when defer=false", async () => {
+		const html = await render(Script, {
+			props: { embedCode: "abc123", defer: false },
+		});
+		expect(html).toMatchInlineSnapshot(
+			`"<script src="https://tinylytics.app/embed/abc123.js"></script>"`,
+		);
+	});
+
+	it("uses /min.js URL when min=true", async () => {
+		const html = await render(Script, {
+			props: { embedCode: "abc123", min: true },
+		});
+		expect(html).toMatchInlineSnapshot(
+			`"<script src="https://tinylytics.app/embed/abc123/min.js" defer></script>"`,
+		);
+	});
+
+	it("appends query flags", async () => {
+		const html = await render(Script, {
+			props: {
+				embedCode: "abc123",
+				hits: true,
+				kudos: "custom",
+				events: true,
+				beacon: true,
+			},
+		});
+		expect(html).toMatchInlineSnapshot(
+			`"<script src="https://tinylytics.app/embed/abc123.js?hits&kudos=custom&events&beacon" defer></script>"`,
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Hits
+// ---------------------------------------------------------------------------
+
+describe("Hits", () => {
+	it("renders a span with tinylytics_hits class", async () => {
+		const html = await render(Hits);
+		expect(html).toMatchInlineSnapshot(`"<span class="tinylytics_hits"></span>"`);
+	});
+
+	it("renders slot content", async () => {
+		const html = await render(Hits, { slots: { default: "1,234" } });
+		expect(html).toMatchInlineSnapshot(
+			`"<span class="tinylytics_hits">1,234</span>"`,
+		);
+	});
+
+	it("renders a custom element via as prop", async () => {
+		const html = await render(Hits, { props: { as: "p" } });
+		expect(html).toMatchInlineSnapshot(`"<p class="tinylytics_hits"></p>"`);
+	});
+
+	it("appends extra class names", async () => {
+		const html = await render(Hits, { props: { class: "my-counter big" } });
+		expect(html).toMatchInlineSnapshot(
+			`"<span class="tinylytics_hits my-counter big"></span>"`,
+		);
+	});
+
+	it("adds data-ignore when ignore=true", async () => {
+		const html = await render(Hits, { props: { ignore: true } });
+		expect(html).toMatchInlineSnapshot(
+			`"<span data-ignore="true" class="tinylytics_hits"></span>"`,
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Kudos
+// ---------------------------------------------------------------------------
+
+describe("Kudos", () => {
+	it("renders a button with tinylytics_kudos class", async () => {
+		const html = await render(Kudos);
+		expect(html).toMatchInlineSnapshot(
+			`"<button type="button" class="tinylytics_kudos"></button>"`,
+		);
+	});
+
+	it("renders slot content", async () => {
+		const html = await render(Kudos, { slots: { default: "👋 Like" } });
+		expect(html).toMatchInlineSnapshot(
+			`"<button type="button" class="tinylytics_kudos">👋 Like</button>"`,
+		);
+	});
+
+	it("adds data-path when path is provided", async () => {
+		const html = await render(Kudos, { props: { path: "/posts/hello" } });
+		expect(html).toMatchInlineSnapshot(
+			`"<button type="button" class="tinylytics_kudos" data-path="/posts/hello"></button>"`,
+		);
+	});
+
+	it("adds data-private when private=true", async () => {
+		const html = await render(Kudos, { props: { private: true } });
+		expect(html).toMatchInlineSnapshot(
+			`"<button type="button" class="tinylytics_kudos" data-private="true"></button>"`,
+		);
+	});
+
+	it("adds data-ignore when ignore=true", async () => {
+		const html = await render(Kudos, { props: { ignore: true } });
+		expect(html).toMatchInlineSnapshot(
+			`"<button type="button" class="tinylytics_kudos" data-ignore="true"></button>"`,
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Countries
+// ---------------------------------------------------------------------------
+
+describe("Countries", () => {
+	it("renders a span with tinylytics_countries class", async () => {
+		const html = await render(Countries);
+		expect(html).toMatchInlineSnapshot(
+			`"<span class="tinylytics_countries"></span>"`,
+		);
+	});
+
+	it("renders a custom element with extra class", async () => {
+		const html = await render(Countries, {
+			props: { as: "div", class: "flags" },
+		});
+		expect(html).toMatchInlineSnapshot(
+			`"<div class="tinylytics_countries flags"></div>"`,
+		);
+	});
+
+	it("adds data-ignore when ignore=true", async () => {
+		const html = await render(Countries, { props: { ignore: true } });
+		expect(html).toMatchInlineSnapshot(
+			`"<span data-ignore="true" class="tinylytics_countries"></span>"`,
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Uptime
+// ---------------------------------------------------------------------------
+
+describe("Uptime", () => {
+	it("renders a span with tinylytics_uptime class", async () => {
+		const html = await render(Uptime);
+		expect(html).toMatchInlineSnapshot(
+			`"<span class="tinylytics_uptime"></span>"`,
+		);
+	});
+
+	it("renders a custom element with extra class", async () => {
+		const html = await render(Uptime, {
+			props: { as: "strong", class: "badge" },
+		});
+		expect(html).toMatchInlineSnapshot(
+			`"<strong class="tinylytics_uptime badge"></strong>"`,
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Webring
+// ---------------------------------------------------------------------------
+
+describe("Webring", () => {
+	it("renders an anchor with tinylytics_webring class opening in a new tab", async () => {
+		const html = await render(Webring, { slots: { default: "Random site" } });
+		expect(html).toMatchInlineSnapshot(
+			`"<a href="#" target="_blank" rel="noopener" class="tinylytics_webring">  Random site  </a>"`,
+		);
+	});
+
+	it("omits target/rel when newTab=false", async () => {
+		const html = await render(Webring, {
+			props: { newTab: false },
+			slots: { default: "Random site" },
+		});
+		expect(html).toMatchInlineSnapshot(
+			`"<a href="#" class="tinylytics_webring">  Random site  </a>"`,
+		);
+	});
+
+	it("renders avatar img before slot content by default", async () => {
+		const html = await render(Webring, {
+			props: { avatar: true },
+			slots: { default: "Next" },
+		});
+		expect(html).toMatchInlineSnapshot(
+			`"<a href="#" target="_blank" rel="noopener" class="tinylytics_webring"> <img class="tinylytics_webring_avatar" src="" style="display: none" alt aria-hidden="true"> Next  </a>"`,
+		);
+	});
+
+	it("renders avatar img after slot content when avatarPosition=after", async () => {
+		const html = await render(Webring, {
+			props: { avatar: true, avatarPosition: "after" },
+			slots: { default: "Next" },
+		});
+		expect(html).toMatchInlineSnapshot(
+			`"<a href="#" target="_blank" rel="noopener" class="tinylytics_webring">  Next <img class="tinylytics_webring_avatar" src="" style="display: none" alt aria-hidden="true"> </a>"`,
+		);
+	});
+
+	it("sets alt text and removes aria-hidden when avatarAlt is provided", async () => {
+		const html = await render(Webring, {
+			props: { avatar: true, avatarAlt: "Avatar for example.com" },
+			slots: { default: "Next" },
+		});
+		expect(html).toMatchInlineSnapshot(
+			`"<a href="#" target="_blank" rel="noopener" class="tinylytics_webring"> <img class="tinylytics_webring_avatar" src="" style="display: none" alt="Avatar for example.com"> Next  </a>"`,
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Event
+// ---------------------------------------------------------------------------
+
+describe("Event", () => {
+	it("renders a button when no href is present", async () => {
+		const html = await render(Event, {
+			props: { name: "nav.click" },
+			slots: { default: "Click me" },
+		});
+		expect(html).toMatchInlineSnapshot(
+			`"<button data-tinylytics-event="nav.click">Click me</button>"`,
+		);
+	});
+
+	it("renders an anchor when href is present", async () => {
+		const html = await render(Event, {
+			props: { name: "file.download", href: "/resume.pdf" },
+			slots: { default: "Download" },
+		});
+		expect(html).toMatchInlineSnapshot(
+			`"<a href="/resume.pdf" data-tinylytics-event="file.download">Download</a>"`,
+		);
+	});
+
+	it("renders the specified element via as prop", async () => {
+		const html = await render(Event, {
+			props: { name: "section.view", as: "div" },
+			slots: { default: "Content" },
+		});
+		expect(html).toMatchInlineSnapshot(
+			`"<div data-tinylytics-event="section.view">Content</div>"`,
+		);
+	});
+
+	it("adds data-tinylytics-event-value when value is provided", async () => {
+		const html = await render(Event, {
+			props: { name: "file.download", value: "resume.pdf", href: "/resume.pdf" },
+			slots: { default: "Download" },
+		});
+		expect(html).toMatchInlineSnapshot(
+			`"<a href="/resume.pdf" data-tinylytics-event="file.download" data-tinylytics-event-value="resume.pdf">Download</a>"`,
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Pixel
+// ---------------------------------------------------------------------------
+
+describe("Pixel", () => {
+	it("renders a 1x1 img with the embed code URL", async () => {
+		const html = await render(Pixel, { props: { embedCode: "abc123" } });
+		expect(html).toMatchInlineSnapshot(
+			`"<img src="https://tinylytics.app/pixel/abc123.gif" alt="" width="1" height="1" style="width:1px;height:1px;border:0;" aria-hidden="true" loading="eager">"`,
+		);
+	});
+
+	it("appends an encoded path parameter", async () => {
+		const html = await render(Pixel, {
+			props: { embedCode: "abc123", path: "/posts/hello-world" },
+		});
+		expect(html).toMatchInlineSnapshot(
+			`"<img src="https://tinylytics.app/pixel/abc123.gif?path=%2Fposts%2Fhello-world" alt="" width="1" height="1" style="width:1px;height:1px;border:0;" aria-hidden="true" loading="eager">"`,
+		);
+	});
+
+	it("normalizes a path missing its leading slash", async () => {
+		const html = await render(Pixel, {
+			props: { embedCode: "abc123", path: "posts/hello" },
+		});
+		expect(html).toMatchInlineSnapshot(
+			`"<img src="https://tinylytics.app/pixel/abc123.gif?path=%2Fposts%2Fhello" alt="" width="1" height="1" style="width:1px;height:1px;border:0;" aria-hidden="true" loading="eager">"`,
+		);
+	});
+});

--- a/packages/astro-tinylytics/test/urls.test.ts
+++ b/packages/astro-tinylytics/test/urls.test.ts
@@ -31,9 +31,7 @@ describe("buildScriptUrl", () => {
 		expect(buildScriptUrl({ embedCode: "x", kudos: "custom" })).toContain(
 			"kudos=custom",
 		);
-		expect(buildScriptUrl({ embedCode: "x", kudos: "❤️" })).toContain(
-			"kudos=❤️",
-		);
+		expect(buildScriptUrl({ embedCode: "x", kudos: "❤️" })).toContain("kudos=❤️");
 	});
 
 	it("appends webring flag variants", () => {

--- a/packages/astro-tinylytics/test/urls.test.ts
+++ b/packages/astro-tinylytics/test/urls.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { buildPixelUrl, buildScriptUrl } from "../src/urls.ts";
+
+describe("buildScriptUrl", () => {
+	it("generates a minimal URL with only embedCode", () => {
+		expect(buildScriptUrl({ embedCode: "abc123" })).toBe(
+			"https://tinylytics.app/embed/abc123.js",
+		);
+	});
+
+	it("uses the minified URL when min=true", () => {
+		expect(buildScriptUrl({ embedCode: "abc123", min: true })).toBe(
+			"https://tinylytics.app/embed/abc123/min.js",
+		);
+	});
+
+	it("appends hits flag", () => {
+		expect(buildScriptUrl({ embedCode: "x", hits: true })).toContain("?hits");
+		expect(buildScriptUrl({ embedCode: "x", hits: "unique" })).toContain(
+			"hits=unique",
+		);
+	});
+
+	it("does not add hits param when hits is false/undefined", () => {
+		const url = buildScriptUrl({ embedCode: "x", hits: false });
+		expect(url).not.toContain("hits");
+	});
+
+	it("appends kudos flag variants", () => {
+		expect(buildScriptUrl({ embedCode: "x", kudos: true })).toContain("kudos");
+		expect(buildScriptUrl({ embedCode: "x", kudos: "custom" })).toContain(
+			"kudos=custom",
+		);
+		expect(buildScriptUrl({ embedCode: "x", kudos: "❤️" })).toContain(
+			"kudos=❤️",
+		);
+	});
+
+	it("appends webring flag variants", () => {
+		expect(buildScriptUrl({ embedCode: "x", webring: true })).toContain(
+			"webring",
+		);
+		expect(buildScriptUrl({ embedCode: "x", webring: "avatars" })).toContain(
+			"webring=avatars",
+		);
+	});
+
+	it("appends boolean flags", () => {
+		const url = buildScriptUrl({
+			embedCode: "x",
+			uptime: true,
+			countries: true,
+			events: true,
+			beacon: true,
+			spa: true,
+			ignore: true,
+		});
+		expect(url).toContain("uptime");
+		expect(url).toContain("countries");
+		expect(url).toContain("events");
+		expect(url).toContain("beacon");
+		expect(url).toContain("spa");
+		expect(url).toContain("ignore");
+	});
+
+	it("builds a realistic URL with multiple flags", () => {
+		const url = buildScriptUrl({
+			embedCode: "7vP3rWZs",
+			hits: true,
+			kudos: "custom",
+			events: true,
+			beacon: true,
+			webring: "avatars",
+		});
+		expect(url).toBe(
+			"https://tinylytics.app/embed/7vP3rWZs.js?hits&kudos=custom&webring=avatars&events&beacon",
+		);
+	});
+});
+
+describe("buildPixelUrl", () => {
+	it("generates a URL with only embedCode", () => {
+		expect(buildPixelUrl("abc123")).toBe(
+			"https://tinylytics.app/pixel/abc123.gif",
+		);
+	});
+
+	it("appends an encoded path parameter", () => {
+		expect(buildPixelUrl("abc123", "/posts/hello-world")).toBe(
+			"https://tinylytics.app/pixel/abc123.gif?path=%2Fposts%2Fhello-world",
+		);
+	});
+
+	it("adds a leading slash to the path if missing", () => {
+		expect(buildPixelUrl("abc123", "posts/hello")).toBe(
+			"https://tinylytics.app/pixel/abc123.gif?path=%2Fposts%2Fhello",
+		);
+	});
+});

--- a/packages/astro-tinylytics/tsconfig.json
+++ b/packages/astro-tinylytics/tsconfig.json
@@ -1,4 +1,4 @@
 {
 	"extends": "astro/tsconfigs/strictest",
-	"include": ["src/**/*", "test/**/*"]
+	"include": ["src/**/*", "test/**/*"],
 }

--- a/packages/astro-tinylytics/tsconfig.json
+++ b/packages/astro-tinylytics/tsconfig.json
@@ -1,5 +1,4 @@
 {
-	"$schema": "https://json.schemastore.org/tsconfig",
-	"extends": "astro/tsconfigs/strict",
-	"include": ["src/**/*"],
+	"extends": "astro/tsconfigs/strictest",
+	"include": ["src/**/*", "test/**/*"]
 }

--- a/packages/astro-tinylytics/vitest.config.ts
+++ b/packages/astro-tinylytics/vitest.config.ts
@@ -1,0 +1,28 @@
+import process from "node:process";
+import { getViteConfig } from "astro/config";
+
+// biome-ignore lint/style/noDefaultExport: correct pattern for config files
+export default getViteConfig({
+	test: {
+		globals: true,
+		watch: false,
+		testTimeout: process.env.GITHUB_ACTIONS ? 15_000 : 5000,
+		reporters: process.env.GITHUB_ACTIONS ? ["github-actions", "junit"] : ["verbose", "junit"],
+		outputFile: { junit: "./_temp/junit.xml" },
+		coverage: {
+			include: ["src/**"],
+			exclude: ["**/*.json", "**/*.md", "**/*.yaml", "**/*.yml", "**/fixtures/**", "**/test/data/**"],
+			provider: "v8",
+			reporter: ["text", "json", "html", "cobertura"],
+			reportsDirectory: ".coverage/vitest",
+		},
+		exclude: [
+			"**/node_modules/**",
+			"**/dist/**",
+			"**/cypress/**",
+			"**/.{idea,git,cache,output,temp}/**",
+			"**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*",
+			"**/fixtures/**",
+		],
+	},
+});

--- a/packages/astro-tinylytics/vitest.config.ts
+++ b/packages/astro-tinylytics/vitest.config.ts
@@ -7,11 +7,20 @@ export default getViteConfig({
 		globals: true,
 		watch: false,
 		testTimeout: process.env.GITHUB_ACTIONS ? 15_000 : 5000,
-		reporters: process.env.GITHUB_ACTIONS ? ["github-actions", "junit"] : ["verbose", "junit"],
+		reporters: process.env.GITHUB_ACTIONS
+			? ["github-actions", "junit"]
+			: ["verbose", "junit"],
 		outputFile: { junit: "./_temp/junit.xml" },
 		coverage: {
 			include: ["src/**"],
-			exclude: ["**/*.json", "**/*.md", "**/*.yaml", "**/*.yml", "**/fixtures/**", "**/test/data/**"],
+			exclude: [
+				"**/*.json",
+				"**/*.md",
+				"**/*.yaml",
+				"**/*.yml",
+				"**/fixtures/**",
+				"**/test/data/**",
+			],
 			provider: "v8",
 			reporter: ["text", "json", "html", "cobertura"],
 			reportsDirectory: ".coverage/vitest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.3.8
         version: 2.3.8
+      '@vitest/coverage-v8':
+        specifier: ^4.0.18
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.3(@types/node@25.2.3)(typescript@5.9.3))(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))
       astro:
         specifier: ^5.17.1
         version: 5.18.1(@netlify/blobs@10.4.1)(@types/node@25.2.3)(ioredis@5.6.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.57.1)(terser@5.44.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
@@ -126,6 +129,9 @@ importers:
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.3(@types/node@25.2.3)(typescript@5.9.3))(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/btree-typescript:
     devDependencies:
@@ -15200,6 +15206,20 @@ snapshots:
       std-env: 3.10.0
       tinyrainbow: 3.0.3
       vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.25)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.3(@types/node@20.19.25)(typescript@5.9.3))(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.3(@types/node@25.2.3)(typescript@5.9.3))(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.18
+      ast-v8-to-istanbul: 0.3.10
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.1
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(happy-dom@20.4.0)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(msw@2.12.3(@types/node@25.2.3)(typescript@5.9.3))(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/expect@4.0.18':
     dependencies:

--- a/repopo.config.ts
+++ b/repopo.config.ts
@@ -93,6 +93,7 @@ const config: RepopoConfig = {
 			{
 				allowedScopes: ["@tylerbu"],
 				unscopedPackages: [
+					"astro-tinylytics",
 					"dill-cli",
 					"dill-docs",
 					"rehype-footnotes",


### PR DESCRIPTION
## Summary

Builds on the initial `astro-tinylytics` package stub by adding the full set of core Tinylytics components extracted from tylerbutler.com, along with typed exports, URL-building utilities, and a test suite.

**Components added** (`src/`): `Script`, `Hits`, `Kudos`, `Countries`, `Uptime`, `Webring`, `Event`, `Pixel` — covering every widget and tracking feature in the Tinylytics docs.

**`src/urls.ts`** — extracts the URL-building logic from `Script` and `Pixel` into `buildScriptUrl` / `buildPixelUrl`, making the query-flag assembly independently testable.

**`src/index.ts` + `src/types.ts`** — barrel export and standalone prop interfaces so consumers can import components and types from a single entry point (`".": "./src/index.ts"`).

**`package.json`** — renames package from `@tylerbu/astro-tinylytics` → `astro-tinylytics` (unscoped, follows Astro ecosystem convention); adds `test:vitest` / `test:coverage` scripts and vitest devDependencies; broadens peer dep to `>=4.0.0`; adds `build` Nx target.

**`tsconfig.json`** — upgrades from `astro/tsconfigs/strict` to `astro/tsconfigs/strictest`; adds `test/**/*` to includes.

**Tests** — 42 tests across two files:
- `test/urls.test.ts` (11): unit tests for `buildScriptUrl` and `buildPixelUrl` covering all flag combinations
- `test/components.test.ts` (31): Astro Container API snapshot tests rendering every component to HTML, covering default output, each significant prop, and slot content

**`repopo.config.ts`** — registers `astro-tinylytics` as an allowed unscoped package name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)