### PR TITLE
ci: replace install-just with tools input in workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,13 +29,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@8a1c4371755898f67cd97006ba7c97702d5fc4bf # ratchet:anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa # ratchet:anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@8a1c4371755898f67cd97006ba7c97702d5fc4bf # ratchet:anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa # ratchet:anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/dependabot-to-issues.yml
+++ b/.github/workflows/dependabot-to-issues.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Create issue from Dependabot PR
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # ratchet:actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
       - uses: ./.github/actions/setup-node-pnpm
 
@@ -45,14 +45,14 @@ jobs:
       coverage-matrix: ${{ steps.coverage-matrix.outputs.matrix }}
 
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           filter: tree:0
           fetch-depth: 0 # Required for nx affected to compare against base branch
 
       - uses: ./.github/actions/setup-node-pnpm
 
-      - uses: tylerbutler/actions/setup-rust@main
+      - uses: tylerbutler/actions/setup-rust@c4c45a8284082163bc58623acfc4b3dc98633c3d # ratchet:tylerbutler/actions/setup-rust@main
         with:
           tools: ''
 
@@ -136,7 +136,7 @@ jobs:
       - name: Upload coverage artifacts
         id: upload-coverage
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # ratchet:actions/upload-artifact@v5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
           name: coverage-reports
           path: packages/*/.coverage/vitest/
@@ -162,10 +162,10 @@ jobs:
         package: ${{ fromJson(needs.build-and-test.outputs.coverage-matrix) }}
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # ratchet:actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # ratchet:actions/download-artifact@v6
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
         with:
           name: coverage-reports
           path: packages/

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: tylerbutler/actions/setup-rust@main
         with:
-          install-just: 'false'
+          tools: ''
 
       # Check if PR has nx-cloud label to opt-in to Nx Cloud
       - name: Check for nx-cloud label

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,20 +22,20 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     permissions:
-      contents: write       # For changesets PR creation
-      pull-requests: write  # For changesets PR updates
-      id-token: write       # OIDC token for npm trusted publishing
-      attestations: write   # For GitHub build attestations
+      contents: write # For changesets PR creation
+      pull-requests: write # For changesets PR updates
+      id-token: write # OIDC token for npm trusted publishing
+      attestations: write # For GitHub build attestations
 
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           token: ${{ secrets.CHANGESET_TOKEN }}
           fetch-depth: 0
 
       - uses: ./.github/actions/setup-node-pnpm
 
-      - uses: tylerbutler/actions/setup-rust@main
+      - uses: tylerbutler/actions/setup-rust@c4c45a8284082163bc58623acfc4b3dc98633c3d # ratchet:tylerbutler/actions/setup-rust@main
         with:
           tools: ''
 
@@ -49,7 +49,7 @@ jobs:
       # the action that was actually taken.
       - name: Process changesets
         id: changesets
-        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # ratchet:changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # ratchet:changesets/action@v1
         with:
           version: pnpm ci:version
           title: "🚀 release: Update versions"
@@ -119,7 +119,7 @@ jobs:
           steps.publish.outputs.report != null &&
           steps.publish.outputs.report != '[]' &&
           github.event.inputs.publish_public != 'false'
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # ratchet:actions/attest-build-provenance@v4
         with:
           subject-path: |
             packages/*/esm/**/*.js
@@ -133,7 +133,7 @@ jobs:
 
       - name: Trigger repopo-core binary release
         if: steps.publish.outputs.report != '[]' && steps.publish.outputs.report != null
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # ratchet:actions/github-script@v9
         with:
           script: |
             const packages = JSON.parse('${{ steps.publish.outputs.report }}');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: tylerbutler/actions/setup-rust@main
         with:
-          install-just: 'false'
+          tools: ''
 
       - uses: ./.github/actions/setup-nx
         with:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -10,9 +10,9 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
-      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # ratchet:pnpm/action-setup@v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # ratchet:pnpm/action-setup@v5
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: "pnpm"
@@ -20,7 +20,7 @@ jobs:
       - run: npm i --global corepack@latest
       - run: corepack enable
 
-      - uses: renovatebot/github-action@f9c81dddc9b589e4e6ae0326d1e36f6bc415d230 # ratchet:renovatebot/github-action@v39.2.4
+      - uses: renovatebot/github-action@f66d8679fcfcfa051abde6e7a623007173bf5164 # ratchet:renovatebot/github-action@v46.1.12
         with:
           configurationFile: renovate.json5
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/repopo-core-release.yml
+++ b/.github/workflows/repopo-core-release.yml
@@ -43,9 +43,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # ratchet:actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
-      - uses: tylerbutler/actions/setup-rust@main
+      - uses: tylerbutler/actions/setup-rust@c4c45a8284082163bc58623acfc4b3dc98633c3d # ratchet:tylerbutler/actions/setup-rust@main
         with:
           targets: ${{ matrix.target }}
           tools: ''
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload artifact (unix)
         if: runner.os != 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset-name }}
           path: |
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload artifact (windows)
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset-name }}
           path: |
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/repopo-core-release.yml
+++ b/.github/workflows/repopo-core-release.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: tylerbutler/actions/setup-rust@main
         with:
           targets: ${{ matrix.target }}
-          install-just: 'false'
+          tools: ''
 
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} --manifest-path packages/repopo/crates/core/Cargo.toml


### PR DESCRIPTION
Fixes #689

Replaces `install-just: 'false'` with `tools: ''` in all three workflow files to prevent `just` from being silently installed after the upstream action change in tylerbutler/actions#27.