### PR TITLE
chore(release): mark packages as 1.0 stable

### DIFF
--- a/.changeset/fine-chicken-remain.md
+++ b/.changeset/fine-chicken-remain.md
@@ -1,0 +1,10 @@
+---
+"rehype-footnotes": major
+"remark-lazy-links": major
+"remark-repopo-policies": major
+"remark-shift-headings": major
+---
+
+1.0 Release
+
+API is stable. Future changes will follow SemVer.


### PR DESCRIPTION
## Summary

Adds a changeset declaring major version bumps for `rehype-footnotes`, `remark-lazy-links`, `remark-repopo-policies`, and `remark-shift-headings`, marking their APIs stable and committing to SemVer going forward.