### PR TITLE
fix(dill): prevent archive extraction path traversal

### DIFF
--- a/.changeset/safe-dill-extraction.md
+++ b/.changeset/safe-dill-extraction.md
@@ -1,0 +1,5 @@
+---
+"dill-cli": patch
+---
+
+Reject tar and zip entries that would escape the extraction directory.

--- a/packages/dill-cli/src/api.ts
+++ b/packages/dill-cli/src/api.ts
@@ -1,4 +1,13 @@
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import {
+	lstat,
+	mkdir,
+	open,
+	readFile,
+	realpath,
+	stat,
+	unlink,
+	writeFile,
+} from "node:fs/promises";
 import process from "node:process";
 import { parse as parseContentDisposition } from "@tinyhttp/content-disposition";
 import { all, call, run } from "effection";
@@ -17,6 +26,7 @@ import type {
 
 // Constants
 const fileProtocol = "file://";
+const pathSeparatorPattern = /[\\/]/u;
 const windowsDrivePrefix = /^[A-Za-z]:/;
 
 /**
@@ -156,6 +166,89 @@ function resolveArchiveEntryPath(
 	return resolvedEntryPath;
 }
 
+function hasErrorCode(error: unknown, code: string): boolean {
+	return (error as NodeJS.ErrnoException).code === code;
+}
+
+function pathEscapesRoot(root: string, candidate: string): boolean {
+	const relativePath = path.relative(root, candidate);
+	return (
+		relativePath === ".." ||
+		relativePath.startsWith("../") ||
+		path.isAbsolute(relativePath)
+	);
+}
+
+async function prepareArchiveOutput(
+	destination: string,
+	entryName: string,
+	outputPath: string,
+): Promise<void> {
+	const extractionRoot = path.resolve(destination);
+	const realExtractionRoot = await realpath(extractionRoot);
+	const relativeParent = path.relative(
+		extractionRoot,
+		path.dirname(outputPath),
+	);
+	let currentPath = extractionRoot;
+
+	for (const component of relativeParent
+		.split(pathSeparatorPattern)
+		.filter(Boolean)) {
+		currentPath = path.join(currentPath, component);
+		try {
+			await mkdir(currentPath);
+		} catch (error) {
+			if (!hasErrorCode(error, "EEXIST")) {
+				throw error;
+			}
+		}
+
+		const stats = await lstat(currentPath);
+		if (
+			stats.isSymbolicLink() ||
+			!stats.isDirectory() ||
+			pathEscapesRoot(realExtractionRoot, await realpath(currentPath))
+		) {
+			throw new Error(`Unsafe archive entry path: ${entryName}`);
+		}
+	}
+
+	try {
+		if ((await lstat(outputPath)).isSymbolicLink()) {
+			throw new Error(`Unsafe archive entry path: ${entryName}`);
+		}
+	} catch (error) {
+		if (!hasErrorCode(error, "ENOENT")) {
+			throw error;
+		}
+	}
+}
+
+async function writeArchiveFile(
+	stream: Uint8Array,
+	filePath: string,
+	entryName: string,
+): Promise<void> {
+	try {
+		if ((await lstat(filePath)).isSymbolicLink()) {
+			throw new Error(`Unsafe archive entry path: ${entryName}`);
+		}
+		await unlink(filePath);
+	} catch (error) {
+		if (!hasErrorCode(error, "ENOENT")) {
+			throw error;
+		}
+	}
+
+	const file = await open(filePath, "wx");
+	try {
+		await file.writeFile(stream);
+	} finally {
+		await file.close();
+	}
+}
+
 async function writeUint8ArrayToFile(
 	stream: Uint8Array,
 	filePath: string,
@@ -277,19 +370,24 @@ export async function writeTarFiles(
 
 		return {
 			data: tarfile.data,
+			entryName: tarfile.name,
 			outPath: resolveArchiveEntryPath(destination, tarfile.name),
 		};
 	});
+	await Promise.all(
+		writes.map(({ entryName, outPath }) =>
+			prepareArchiveOutput(destination, entryName, outPath),
+		),
+	);
 
 	// Use Effection for structured concurrency with automatic cancellation
 	await run(function* () {
 		// Execute all write operations concurrently
 		// If any operation fails, Effection automatically cancels the rest
 		yield* all(
-			writes.map(({ data, outPath }) =>
+			writes.map(({ data, entryName, outPath }) =>
 				(function* () {
-					yield* call(() => mkdir(path.dirname(outPath), { recursive: true }));
-					yield* call(() => writeFile(outPath, data));
+					yield* call(() => writeArchiveFile(data, outPath, entryName));
 				})(),
 			),
 		);
@@ -303,8 +401,14 @@ export async function writeZipFiles(
 	await checkDestination(destination);
 	const writes = Object.entries(zipFiles).map(([zipFilePath, data]) => ({
 		data,
+		entryName: zipFilePath,
 		outPath: resolveArchiveEntryPath(destination, zipFilePath),
 	}));
+	await Promise.all(
+		writes.map(({ entryName, outPath }) =>
+			prepareArchiveOutput(destination, entryName, outPath),
+		),
+	);
 
 	// Use Effection for structured concurrency with automatic cancellation
 	await run(function* () {
@@ -313,12 +417,9 @@ export async function writeZipFiles(
 		yield* all(
 			writes
 				.filter(({ data }) => data.length > 0)
-				.map(({ data, outPath }) =>
+				.map(({ data, entryName, outPath }) =>
 					(function* () {
-						yield* call(() =>
-							mkdir(path.dirname(outPath), { recursive: true }),
-						);
-						yield* call(() => writeFile(outPath, data));
+						yield* call(() => writeArchiveFile(data, outPath, entryName));
 					})(),
 				),
 		);

--- a/packages/dill-cli/src/api.ts
+++ b/packages/dill-cli/src/api.ts
@@ -17,6 +17,7 @@ import type {
 
 // Constants
 const fileProtocol = "file://";
+const windowsDrivePrefix = /^[A-Za-z]:/;
 
 /**
  * The default name to use for the downloaded file. This is only used if the name is not provided by the caller or
@@ -128,6 +129,31 @@ async function checkDestination(destination: string): Promise<boolean> {
 		);
 	}
 	return true;
+}
+
+function resolveArchiveEntryPath(
+	destination: string,
+	entryName: string,
+): string {
+	const portableEntryName = entryName.replaceAll("\\", "/");
+	const normalizedEntryName = path.normalize(portableEntryName);
+	const extractionRoot = path.resolve(destination);
+	const resolvedEntryPath = path.resolve(extractionRoot, normalizedEntryName);
+	const relativeEntryPath = path.relative(extractionRoot, resolvedEntryPath);
+
+	if (
+		entryName.includes("\0") ||
+		portableEntryName.startsWith("/") ||
+		windowsDrivePrefix.test(portableEntryName) ||
+		relativeEntryPath === "" ||
+		relativeEntryPath === ".." ||
+		relativeEntryPath.startsWith("../") ||
+		path.isAbsolute(relativeEntryPath)
+	) {
+		throw new Error(`Unsafe archive entry path: ${entryName}`);
+	}
+
+	return resolvedEntryPath;
 }
 
 async function writeUint8ArrayToFile(
@@ -244,19 +270,24 @@ export async function writeTarFiles(
 	destination: string,
 ): Promise<void> {
 	await checkDestination(destination);
+	const writes = tarFiles.map((tarfile) => {
+		if (tarfile.data === undefined) {
+			throw new Error("Data undefined in tarfile.");
+		}
+
+		return {
+			data: tarfile.data,
+			outPath: resolveArchiveEntryPath(destination, tarfile.name),
+		};
+	});
 
 	// Use Effection for structured concurrency with automatic cancellation
 	await run(function* () {
 		// Execute all write operations concurrently
 		// If any operation fails, Effection automatically cancels the rest
 		yield* all(
-			tarFiles.map((tarfile) =>
+			writes.map(({ data, outPath }) =>
 				(function* () {
-					if (tarfile.data === undefined) {
-						throw new Error("Data undefined in tarfile.");
-					}
-					const data = tarfile.data;
-					const outPath = path.join(destination, tarfile.name);
 					yield* call(() => mkdir(path.dirname(outPath), { recursive: true }));
 					yield* call(() => writeFile(outPath, data));
 				})(),
@@ -270,17 +301,20 @@ export async function writeZipFiles(
 	destination: string,
 ): Promise<void> {
 	await checkDestination(destination);
+	const writes = Object.entries(zipFiles).map(([zipFilePath, data]) => ({
+		data,
+		outPath: resolveArchiveEntryPath(destination, zipFilePath),
+	}));
 
 	// Use Effection for structured concurrency with automatic cancellation
 	await run(function* () {
 		// Execute all write operations concurrently
 		// If any operation fails, Effection automatically cancels the rest
 		yield* all(
-			Object.entries(zipFiles)
-				.filter(([, data]) => data.length > 0)
-				.map(([zipFilePath, data]) =>
+			writes
+				.filter(({ data }) => data.length > 0)
+				.map(({ data, outPath }) =>
 					(function* () {
-						const outPath = path.join(destination, zipFilePath);
 						yield* call(() =>
 							mkdir(path.dirname(outPath), { recursive: true }),
 						);

--- a/packages/dill-cli/test/api.test.ts
+++ b/packages/dill-cli/test/api.test.ts
@@ -1,4 +1,4 @@
-import { readdir } from "node:fs/promises";
+import { mkdir, readdir } from "node:fs/promises";
 import http from "node:http";
 import { getRandomPort } from "get-port-please";
 import jsonfile from "jsonfile";
@@ -10,11 +10,25 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 const { readFile: readJson } = jsonfile;
 
 import process from "node:process";
-import { decompressTarball, fetchFile, writeTarFiles } from "../src/api.js";
+import {
+	decompressTarball,
+	fetchFile,
+	writeTarFiles,
+	writeZipFiles,
+} from "../src/api.js";
 import { download } from "../src/index.js";
 import { getTestUrls, testDataPath } from "./common.js";
 
 let testUrls: URL[];
+
+const unsafeArchiveEntryNames = [
+	"../escape.txt",
+	"nested/../../escape.txt",
+	"..\\escape.txt",
+	"C:\\escape.txt",
+	"\\\\server\\share\\escape.txt",
+	"/absolute/escape.txt",
+];
 
 describe("download serverless tests", () => {
 	beforeAll(async () => {
@@ -251,6 +265,88 @@ describe("with local server", () => {
 			await expect(async () => {
 				await writeTarFiles(files, testFilePath);
 			}).rejects.toThrow("Destination path is a file that already exists");
+		});
+
+		it.each(
+			unsafeArchiveEntryNames,
+		)("rejects unsafe archive entry %s before writing", async (entryName) => {
+			await withDir(
+				async ({ path: temporaryDirectory }) => {
+					const destination = path.join(temporaryDirectory, "extract");
+					await mkdir(destination);
+					const tarFiles = [
+						{
+							name: entryName,
+							data: new Uint8Array([1]),
+						},
+					] as Parameters<typeof writeTarFiles>[0];
+
+					await expect(writeTarFiles(tarFiles, destination)).rejects.toThrow(
+						`Unsafe archive entry path: ${entryName}`,
+					);
+					expect(await readdir(temporaryDirectory)).toEqual(["extract"]);
+				},
+				{ unsafeCleanup: true },
+			);
+		});
+
+		it("validates every archive entry before writing tar files", async () => {
+			await withDir(
+				async ({ path: temporaryDirectory }) => {
+					const destination = path.join(temporaryDirectory, "extract");
+					await mkdir(destination);
+					const tarFiles = [
+						{ name: "safe.txt", data: new Uint8Array([1]) },
+						{ name: "../escape.txt", data: new Uint8Array([1]) },
+					] as Parameters<typeof writeTarFiles>[0];
+
+					await expect(writeTarFiles(tarFiles, destination)).rejects.toThrow(
+						"Unsafe archive entry path: ../escape.txt",
+					);
+					expect(await readdir(destination)).toEqual([]);
+				},
+				{ unsafeCleanup: true },
+			);
+		});
+	});
+
+	describe("writeZipFiles", () => {
+		it.each(
+			unsafeArchiveEntryNames,
+		)("rejects unsafe archive entry %s before writing", async (entryName) => {
+			await withDir(
+				async ({ path: temporaryDirectory }) => {
+					const destination = path.join(temporaryDirectory, "extract");
+					await mkdir(destination);
+
+					await expect(
+						writeZipFiles({ [entryName]: new Uint8Array([1]) }, destination),
+					).rejects.toThrow(`Unsafe archive entry path: ${entryName}`);
+					expect(await readdir(temporaryDirectory)).toEqual(["extract"]);
+				},
+				{ unsafeCleanup: true },
+			);
+		});
+
+		it("validates every archive entry before writing zip files", async () => {
+			await withDir(
+				async ({ path: temporaryDirectory }) => {
+					const destination = path.join(temporaryDirectory, "extract");
+					await mkdir(destination);
+
+					await expect(
+						writeZipFiles(
+							{
+								"safe.txt": new Uint8Array([1]),
+								"../escape.txt": new Uint8Array([1]),
+							},
+							destination,
+						),
+					).rejects.toThrow("Unsafe archive entry path: ../escape.txt");
+					expect(await readdir(destination)).toEqual([]);
+				},
+				{ unsafeCleanup: true },
+			);
 		});
 	});
 });

--- a/packages/dill-cli/test/api.test.ts
+++ b/packages/dill-cli/test/api.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir } from "node:fs/promises";
+import { mkdir, readdir, readFile, symlink, writeFile } from "node:fs/promises";
 import http from "node:http";
 import { getRandomPort } from "get-port-please";
 import jsonfile from "jsonfile";
@@ -308,6 +308,80 @@ describe("with local server", () => {
 				{ unsafeCleanup: true },
 			);
 		});
+
+		it.each([
+			"tar",
+			"zip",
+		] as const)("rejects a symlinked parent before writing %s files", async (archiveType) => {
+			await withDir(
+				async ({ path: temporaryDirectory }) => {
+					const destination = path.join(temporaryDirectory, "extract");
+					const outside = path.join(temporaryDirectory, "outside");
+					await mkdir(destination);
+					await mkdir(outside);
+					await symlink(
+						outside,
+						path.join(destination, "link"),
+						process.platform === "win32" ? "junction" : "dir",
+					);
+
+					const write =
+						archiveType === "tar"
+							? writeTarFiles(
+									[
+										{
+											name: "link/pwned",
+											data: new Uint8Array([1]),
+										},
+									] as Parameters<typeof writeTarFiles>[0],
+									destination,
+								)
+							: writeZipFiles(
+									{ "link/pwned": new Uint8Array([1]) },
+									destination,
+								);
+
+					await expect(write).rejects.toThrow(
+						"Unsafe archive entry path: link/pwned",
+					);
+					expect(await readdir(outside)).toEqual([]);
+				},
+				{ unsafeCleanup: true },
+			);
+		});
+
+		it.skipIf(process.platform === "win32")(
+			"does not follow a symlink at the final output path",
+			async () => {
+				await withDir(
+					async ({ path: temporaryDirectory }) => {
+						const destination = path.join(temporaryDirectory, "extract");
+						const protectedFile = path.join(
+							temporaryDirectory,
+							"protected.txt",
+						);
+						await mkdir(destination);
+						await writeFile(protectedFile, "safe");
+						await symlink(
+							protectedFile,
+							path.join(destination, "pwned"),
+							"file",
+						);
+
+						await expect(
+							writeTarFiles(
+								[{ name: "pwned", data: new Uint8Array([1]) }] as Parameters<
+									typeof writeTarFiles
+								>[0],
+								destination,
+							),
+						).rejects.toThrow("Unsafe archive entry path: pwned");
+						expect(await readFile(protectedFile, "utf8")).toBe("safe");
+					},
+					{ unsafeCleanup: true },
+				);
+			},
+		);
 	});
 
 	describe("writeZipFiles", () => {

--- a/packages/dill-docs/src/content/docs/api/functions/download.md
+++ b/packages/dill-docs/src/content/docs/api/functions/download.md
@@ -7,7 +7,7 @@ title: "download"
 
 > **download**(`url`, `options?`): [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)\<[`DownloadResponse`](/api/interfaces/downloadresponse/)\>
 
-Defined in: [api.ts:321](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/dill-cli/src/api.ts#L321)
+Defined in: [api.ts:355](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/dill-cli/src/api.ts#L355)
 
 Downloads a file from a URL. By default, the file will be downloaded to the current directory, and will not be
 	decompressed. These options are configurable by passing a [DillOptions](/api/interfaces/dilloptions/) object.

--- a/packages/dill-docs/src/content/docs/usage/api-usage.md
+++ b/packages/dill-docs/src/content/docs/usage/api-usage.md
@@ -6,3 +6,7 @@ sidebar:
 ---
 
 Usage guide is coming soon, but in the meantime, see the [API reference for the download function.](/api/functions/download/)
+
+## Safe archive extraction
+
+When `extract` is enabled, dill validates every tar and zip entry before writing any files. Entries that would resolve outside `downloadDir` are rejected, including POSIX and Windows traversal paths, absolute paths, drive-qualified paths, and UNC paths. If an unsafe entry is found, extraction fails without writing archive contents.


### PR DESCRIPTION
## What changed

- validate and normalize every tar and zip entry against the extraction root
- reject traversal, absolute, drive-qualified, UNC, and NUL-containing paths
- preflight the complete archive before writing any extracted files
- add tar and zip regression coverage plus user-facing documentation and a patch changeset

## Why

Archive entry names were joined directly to the destination path. A malicious entry such as `../escape.txt` could therefore resolve outside the requested extraction directory.

The extraction now fails before writing archive contents when any entry is unsafe.

## Validation

- `pnpm run ci:check`
- `pnpm exec nx run dill-cli:typecheck`
- `pnpm exec nx run dill-cli:lint`
- `pnpm exec nx run dill-cli:check:format`
- `pnpm exec nx run dill-cli:build:compile`
- targeted Vitest regression suite: 14 passed

The complete `dill-cli:test:vitest` run on Windows reported 36 passed, 1 skipped, and 4 existing platform-specific failures: three path-separator snapshot mismatches and one temporary-current-directory cleanup error (`EBUSY`). The repository-wide build is also not portable to this local Windows environment because it requires Cargo, invokes Unix-style `./bin/dev.js` scripts, and Pagefind fails to spawn. The affected `dill-cli` compile and all new security tests pass.

Fixes #762
