### PR TITLE
fix(repopo): correct file processing statistics

### DIFF
--- a/.changeset/repopo-file-statistics.md
+++ b/.changeset/repopo-file-statistics.md
@@ -1,0 +1,5 @@
+---
+"repopo": patch
+---
+
+Correct file processing statistics and ignore empty Git and stdin path records.

--- a/docs/superpowers/plans/2026-07-20-repopo-file-statistics.md
+++ b/docs/superpowers/plans/2026-07-20-repopo-file-statistics.md
@@ -1,0 +1,398 @@
+# Repopo File Statistics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Correct Repopo's file statistics and prevent empty Git/stdin records from entering policy processing.
+
+**Architecture:** Add one pure internal parser for Git/stdin file lists and route both command input paths through it. Keep statistics file-based by incrementing `processed` once after a candidate passes global exclusions, independent of policy matches or policy instance count.
+
+**Tech Stack:** TypeScript, OCLIF, Effection, Vitest, Nx, pnpm, Biome
+
+---
+
+### Task 1: Normalize Git and stdin file lists
+
+**Files:**
+- Create: `packages/repopo/src/filePaths.ts`
+- Create: `packages/repopo/test/filePaths.test.ts`
+- Modify: `packages/repopo/src/commands/check.ts:8-17,110-147`
+
+- [ ] **Step 1: Write the failing parser tests**
+
+Create `packages/repopo/test/filePaths.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+
+import { parseFilePaths } from "../src/filePaths.js";
+
+describe("parseFilePaths", () => {
+	it.each([
+		{ name: "empty input", input: "", expected: [] },
+		{
+			name: "trailing LF",
+			input: "src/one.ts\nsrc/two.ts\n",
+			expected: ["src/one.ts", "src/two.ts"],
+		},
+		{
+			name: "trailing CRLF",
+			input: "src/one.ts\r\nsrc/two.ts\r\n",
+			expected: ["src/one.ts", "src/two.ts"],
+		},
+		{
+			name: "empty records and Windows separators",
+			input: "src\\one.ts\n\nsrc\\two.ts\n",
+			expected: ["src/one.ts", "src/two.ts"],
+		},
+	])("parses $name", ({ input, expected }) => {
+		expect(parseFilePaths(input)).toEqual(expected);
+	});
+});
+```
+
+- [ ] **Step 2: Run the parser tests and verify they fail**
+
+Run:
+
+```bash
+pnpm nx run repopo:test:vitest -- --run test/filePaths.test.ts
+```
+
+Expected: FAIL because `../src/filePaths.js` does not exist.
+
+- [ ] **Step 3: Implement the parser**
+
+Create `packages/repopo/src/filePaths.ts`:
+
+```typescript
+export function parseFilePaths(input: string): string[] {
+	return input
+		.replace(/\\/g, "/")
+		.split(/\r?\n/)
+		.filter((filePath) => filePath.length > 0);
+}
+```
+
+- [ ] **Step 4: Route both command input paths through the parser**
+
+Add this import to `packages/repopo/src/commands/check.ts`:
+
+```typescript
+import { parseFilePaths } from "../filePaths.js";
+```
+
+Replace the stdin normalization block with:
+
+```typescript
+if (stdInput !== undefined && stdInput !== null) {
+	return parseFilePaths(stdInput);
+}
+```
+
+Replace the Git output normalization block with:
+
+```typescript
+return parseFilePaths(gitFiles);
+```
+
+- [ ] **Step 5: Run the parser tests and verify they pass**
+
+Run:
+
+```bash
+pnpm nx run repopo:test:vitest -- --run test/filePaths.test.ts
+```
+
+Expected: PASS with four parser cases.
+
+- [ ] **Step 6: Commit input normalization**
+
+```bash
+git add packages/repopo/src/filePaths.ts packages/repopo/src/commands/check.ts packages/repopo/test/filePaths.test.ts
+git commit -m "fix(repopo): normalize file list input"
+```
+
+### Task 2: Correct file-level processing statistics
+
+**Files:**
+- Modify: `packages/repopo/src/perf.ts:11-19`
+- Modify: `packages/repopo/src/runner.ts:98-123`
+- Modify: `packages/repopo/test/runner.test.ts:27-132`
+
+- [ ] **Step 1: Strengthen the empty and fully processed assertions**
+
+In `packages/repopo/test/runner.test.ts`, add the `processed` assertions:
+
+```typescript
+it("should return empty results for no files", async () => {
+	const runner = new PolicyRunner(makeRunnerOptions());
+	const results = await run(() => runner.run([]));
+	expect(results.results).toEqual([]);
+	expect(results.perfStats.count).toBe(0);
+	expect(results.perfStats.processed).toBe(0);
+});
+
+it("should count candidates admitted past global exclusions as processed", async () => {
+	const runner = new PolicyRunner(makeRunnerOptions());
+	const results = await run(() => runner.run(["a.txt", "b.txt", "c.txt"]));
+	expect(results.perfStats.count).toBe(3);
+	expect(results.perfStats.processed).toBe(3);
+});
+```
+
+- [ ] **Step 2: Add all-excluded and mixed-input assertions**
+
+Extend the existing global exclusion test with:
+
+```typescript
+expect(results.perfStats.count).toBe(1);
+expect(results.perfStats.processed).toBe(0);
+```
+
+Add this test in the `exclusion logic` describe block:
+
+```typescript
+it("should count mixed processed and globally excluded files", async () => {
+	const runner = new PolicyRunner(
+		makeRunnerOptions({
+			excludeFromAll: [/generated/],
+		}),
+	);
+
+	const results = await run(() =>
+		runner.run(["src/index.ts", "generated/output.ts", "README.md"]),
+	);
+
+	expect(results.perfStats.count).toBe(3);
+	expect(results.perfStats.processed).toBe(2);
+});
+```
+
+- [ ] **Step 3: Add duplicate-policy regression coverage**
+
+Add this test in the `run` describe block:
+
+```typescript
+it("should count a file once when multiple policy instances process it", async () => {
+	let handlerCalls = 0;
+	const policyDefinition: PolicyShape = {
+		name: "DuplicatePolicy",
+		description: "Configured more than once",
+		match: /\.txt$/,
+		handler: async () => {
+			handlerCalls++;
+			return true;
+		},
+	};
+
+	const runner = new PolicyRunner(
+		makeRunnerOptions({
+			policies: [policy(policyDefinition), policy(policyDefinition)],
+		}),
+	);
+
+	const results = await run(() => runner.run(["file.txt"]));
+
+	expect(handlerCalls).toBe(2);
+	expect(results.perfStats.count).toBe(1);
+	expect(results.perfStats.processed).toBe(1);
+});
+```
+
+- [ ] **Step 4: Run the runner tests and verify they fail**
+
+Run:
+
+```bash
+pnpm nx run repopo:test:vitest -- --run test/runner.test.ts
+```
+
+Expected: FAIL because `processed` remains zero for admitted files.
+
+- [ ] **Step 5: Document the statistics fields**
+
+Update `PolicyHandlerPerfStats` in `packages/repopo/src/perf.ts`:
+
+```typescript
+export interface PolicyHandlerPerfStats {
+	/** Number of non-empty candidate file paths supplied to the runner. */
+	count: number;
+	/** Number of candidate files admitted past global exclusions. */
+	processed: number;
+	data: Map<PolicyAction, Map<PolicyName, number>>;
+}
+```
+
+- [ ] **Step 6: Increment processed once per admitted file**
+
+Update `routeToPolicies` in `packages/repopo/src/runner.ts`:
+
+```typescript
+private *routeToPolicies(relPath: string): Operation<void> {
+	if (this.excludeFromAll.some((regex) => regex.test(relPath))) {
+		this.logger?.verbose(`Excluded all handlers: ${relPath}`);
+		return;
+	}
+
+	this.perfStats.processed++;
+
+	const matchingPolicies = this.policies.filter((policy) =>
+		policy.match.test(relPath),
+	);
+	yield* all(
+		matchingPolicies.map((policy) => {
+			return this.runPolicyOnFile(relPath, policy);
+		}),
+	);
+}
+```
+
+- [ ] **Step 7: Run the runner tests and verify they pass**
+
+Run:
+
+```bash
+pnpm nx run repopo:test:vitest -- --run test/runner.test.ts
+```
+
+Expected: PASS, including empty, all-excluded, mixed, and duplicate-policy cases.
+
+- [ ] **Step 8: Commit corrected statistics**
+
+```bash
+git add packages/repopo/src/perf.ts packages/repopo/src/runner.ts packages/repopo/test/runner.test.ts
+git commit -m "fix(repopo): correct file processing statistics"
+```
+
+### Task 3: Verify summary output and release metadata
+
+**Files:**
+- Modify: `packages/repopo/test/perf.test.ts:46-60`
+- Create: `.changeset/fuzzy-files-count.md`
+
+- [ ] **Step 1: Make the summary test represent mixed input**
+
+Replace the first `logStats` test data and expectation in `packages/repopo/test/perf.test.ts`:
+
+```typescript
+it("should log statistics summary", () => {
+	const logger = createMockLogger();
+
+	const stats: PolicyHandlerPerfStats = {
+		count: 3,
+		processed: 2,
+		data: new Map(),
+	};
+
+	logStats(stats, logger);
+
+	expect(logger.log).toHaveBeenCalledWith(
+		"Statistics: 2 files processed, 1 excluded, 3 total",
+	);
+});
+```
+
+- [ ] **Step 2: Run all focused regression tests**
+
+Run:
+
+```bash
+pnpm nx run repopo:test:vitest -- --run test/filePaths.test.ts test/runner.test.ts test/perf.test.ts
+```
+
+Expected: PASS for all three test files.
+
+- [ ] **Step 3: Add the patch changeset**
+
+Create `.changeset/fuzzy-files-count.md`:
+
+```markdown
+---
+"repopo": patch
+---
+
+Correct file processing statistics and ignore empty Git and stdin path records.
+```
+
+- [ ] **Step 4: Format the affected project**
+
+Run:
+
+```bash
+pnpm nx run repopo:format
+```
+
+Expected: SUCCESS; inspect any formatting changes before staging.
+
+- [ ] **Step 5: Run targeted project validation**
+
+Run:
+
+```bash
+pnpm nx run repopo:check
+pnpm nx run repopo:lint
+pnpm nx run repopo:build:compile
+pnpm nx run repopo:test:vitest -- --run
+```
+
+Expected: all commands succeed.
+
+- [ ] **Step 6: Review the final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --check
+git diff --no-ext-diff origin/main...HEAD
+git diff --no-ext-diff
+```
+
+Expected: only the design, implementation, tests, and changeset for #777 are present.
+
+- [ ] **Step 7: Commit tests and release metadata**
+
+```bash
+git add packages/repopo/test/perf.test.ts .changeset/fuzzy-files-count.md
+git commit -m "test(repopo): cover corrected file statistics"
+```
+
+### Task 4: Publish the branch and open the pull request
+
+**Files:**
+- No repository file changes.
+
+- [ ] **Step 1: Recheck for a competing open pull request**
+
+Run:
+
+```bash
+gh search prs --repo tylerbutler/tools-monorepo --state open --limit 50 '777 OR "Correct file processing statistics" OR "input normalization"'
+```
+
+Expected: no open PR for #777. If one exists, stop before pushing and compare its scope.
+
+- [ ] **Step 2: Push the issue branch**
+
+Run:
+
+```bash
+git push -u origin fix/repopo-file-statistics-777
+```
+
+Expected: the remote branch is created successfully.
+
+- [ ] **Step 3: Open the pull request**
+
+Run:
+
+```bash
+gh pr create \
+	--repo tylerbutler/tools-monorepo \
+	--base main \
+	--head fix/repopo-file-statistics-777 \
+	--title "fix(repopo): correct file processing statistics" \
+	--body $'## Summary\n\n- normalize Git and stdin file lists before policy processing\n- count processed files once after global exclusions\n- cover empty, excluded, mixed, and duplicate-policy inputs\n\nFixes #777'
+```
+
+Expected: GitHub returns the new pull request URL.

--- a/docs/superpowers/specs/2026-07-20-repopo-file-statistics-design.md
+++ b/docs/superpowers/specs/2026-07-20-repopo-file-statistics-design.md
@@ -1,0 +1,51 @@
+# Repopo File Statistics and Input Normalization
+
+## Issue
+
+Fix [#777](https://github.com/tylerbutler/tools-monorepo/issues/777). No open pull request references the issue or overlaps its file-statistics and input-normalization scope.
+
+## Semantics
+
+Statistics remain file-based:
+
+- `count` is the number of non-empty candidate file paths supplied to `PolicyRunner`.
+- `processed` is the number of candidates admitted past global exclusions.
+- Excluded files are derived as `count - processed`.
+
+Per-policy exclusions do not exclude a file from the run as a whole. A file is counted as processed once even when no policy matches, every matching policy excludes it, or multiple policy instances handle it.
+
+## Input normalization
+
+Move the duplicated Git/stdin output parsing into a small internal helper. The helper:
+
+- normalizes backslashes to forward slashes;
+- splits LF and CRLF line records;
+- removes empty records without trimming valid path content.
+
+Both stdin and `git ls-files` output use this helper before invoking `PolicyRunner`.
+
+## Runner changes
+
+`PolicyRunner` increments `count` once for each candidate. It increments `processed` once after the candidate passes global exclusions and before routing it to matching policies. Policy matches and handler executions never alter file counts.
+
+The existing summary format remains unchanged:
+
+`Statistics: N files processed, M excluded, T total`
+
+## Error handling
+
+Input normalization is deterministic and does not suppress Git, stdin, policy, or handler errors. Existing errors continue to propagate through the current command and runner paths.
+
+## Tests
+
+Add focused regression coverage for:
+
+- empty input;
+- LF and CRLF trailing newlines;
+- empty records in file-list input;
+- all candidates globally excluded;
+- mixed processed and globally excluded candidates;
+- multiple policy instances processing the same file without double-counting it;
+- summary output using the corrected counts.
+
+Implementation will follow test-driven development and use the existing Vitest and Nx tasks.

--- a/packages/repopo-docs/src/content/docs/api/classes/PolicyRunner.md
+++ b/packages/repopo-docs/src/content/docs/api/classes/PolicyRunner.md
@@ -5,7 +5,7 @@ prev: false
 title: "PolicyRunner"
 ---
 
-Defined in: [runner.ts:67](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L67)
+Defined in: [runner.ts:81](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L81)
 
 Runs configured policies against files and collects results.
 
@@ -19,7 +19,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **new PolicyRunner**(`options`): `PolicyRunner`
 
-Defined in: [runner.ts:78](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L78)
+Defined in: [runner.ts:92](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L92)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -41,7 +41,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **run**(`filePaths`): `Operation`\<[`PolicyRunResults`](/api/interfaces/policyrunresults/)\>
 
-Defined in: [runner.ts:87](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L87)
+Defined in: [runner.ts:101](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L101)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.

--- a/packages/repopo-docs/src/content/docs/api/interfaces/PolicyFileResult.md
+++ b/packages/repopo-docs/src/content/docs/api/interfaces/PolicyFileResult.md
@@ -5,7 +5,7 @@ prev: false
 title: "PolicyFileResult"
 ---
 
-Defined in: [runner.ts:32](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L32)
+Defined in: [runner.ts:46](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L46)
 
 Result of running a single policy on a single file.
 
@@ -19,7 +19,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **file**: `string`
 
-Defined in: [runner.ts:33](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L33)
+Defined in: [runner.ts:47](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L47)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -31,7 +31,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **outcome**: [`PolicyHandlerResult`](/api/type-aliases/policyhandlerresult/)
 
-Defined in: [runner.ts:36](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L36)
+Defined in: [runner.ts:50](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L50)
 
 The raw result from the policy handler
 
@@ -45,7 +45,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **policy**: `string`
 
-Defined in: [runner.ts:34](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L34)
+Defined in: [runner.ts:48](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L48)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -57,7 +57,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **resolution?**: [`PolicyFixResult`](/api/interfaces/policyfixresult/)
 
-Defined in: [runner.ts:38](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L38)
+Defined in: [runner.ts:52](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L52)
 
 Set when a standalone resolver was attempted (legacy resolver path)
 

--- a/packages/repopo-docs/src/content/docs/api/interfaces/PolicyRunResults.md
+++ b/packages/repopo-docs/src/content/docs/api/interfaces/PolicyRunResults.md
@@ -5,7 +5,7 @@ prev: false
 title: "PolicyRunResults"
 ---
 
-Defined in: [runner.ts:45](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L45)
+Defined in: [runner.ts:59](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L59)
 
 Aggregated results from a full policy run.
 
@@ -19,7 +19,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **perfStats**: [`PolicyHandlerPerfStats`](/api/interfaces/policyhandlerperfstats/)
 
-Defined in: [runner.ts:47](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L47)
+Defined in: [runner.ts:61](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L61)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -31,7 +31,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **results**: [`PolicyFileResult`](/api/interfaces/policyfileresult/)[]
 
-Defined in: [runner.ts:46](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L46)
+Defined in: [runner.ts:60](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L60)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.

--- a/packages/repopo-docs/src/content/docs/api/interfaces/PolicyRunnerOptions.md
+++ b/packages/repopo-docs/src/content/docs/api/interfaces/PolicyRunnerOptions.md
@@ -5,7 +5,7 @@ prev: false
 title: "PolicyRunnerOptions"
 ---
 
-Defined in: [runner.ts:54](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L54)
+Defined in: [runner.ts:68](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L68)
 
 Options for configuring a [PolicyRunner](/api/classes/policyrunner/).
 
@@ -19,7 +19,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **excludeFromAll**: [`RegExp`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp)[]
 
-Defined in: [runner.ts:56](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L56)
+Defined in: [runner.ts:70](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L70)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -31,7 +31,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **excludePoliciesForFiles**: [`ExcludedPolicyFileMap`](/api/type-aliases/excludedpolicyfilemap/)
 
-Defined in: [runner.ts:57](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L57)
+Defined in: [runner.ts:71](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L71)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -43,7 +43,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **gitRoot**: `string`
 
-Defined in: [runner.ts:58](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L58)
+Defined in: [runner.ts:72](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L72)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -55,7 +55,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **logger?**: [`Pick`](https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys)\<`Logger`, `"verbose"`\>
 
-Defined in: [runner.ts:60](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L60)
+Defined in: [runner.ts:74](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L74)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -67,7 +67,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **policies**: [`PolicyInstance`](/api/type-aliases/policyinstance/)[]
 
-Defined in: [runner.ts:55](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L55)
+Defined in: [runner.ts:69](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L69)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -79,7 +79,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **resolve**: `boolean`
 
-Defined in: [runner.ts:59](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L59)
+Defined in: [runner.ts:73](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L73)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.

--- a/packages/repopo/api-docs/repopo.api.md
+++ b/packages/repopo/api-docs/repopo.api.md
@@ -213,11 +213,9 @@ export type PolicyHandler<C = unknown | undefined> = ((args: PolicyArgs<C>) => P
 
 // @alpha
 export interface PolicyHandlerPerfStats {
-    // (undocumented)
     count: number;
     // (undocumented)
     data: Map<PolicyAction, Map<PolicyName, number>>;
-    // (undocumented)
     processed: number;
 }
 

--- a/packages/repopo/src/commands/check.ts
+++ b/packages/repopo/src/commands/check.ts
@@ -7,6 +7,7 @@ import chalk from "picocolors";
 
 import { BaseRepopoCommand } from "../baseCommand.js";
 import type { RepopoCommandContext } from "../context.js";
+import { parseFilePaths } from "../filePaths.js";
 import { logStats } from "../perf.js";
 import {
 	isPolicyError,
@@ -114,13 +115,7 @@ export class CheckPolicy<
 			});
 
 			if (stdInput !== undefined && stdInput !== null) {
-				return stdInput
-					.replace(
-						// normalize slashes in case they're windows paths
-						/\\/g,
-						"/",
-					)
-					.split("\n");
+				return parseFilePaths(stdInput);
 			}
 
 			return [];
@@ -137,13 +132,7 @@ export class CheckPolicy<
 				"--full-name",
 			)) ?? "";
 
-		return gitFiles
-			.replace(
-				// normalize slashes in case they're windows paths
-				/\\/g,
-				"/",
-			)
-			.split("\n");
+		return parseFilePaths(gitFiles);
 	}
 
 	/**

--- a/packages/repopo/src/filePaths.ts
+++ b/packages/repopo/src/filePaths.ts
@@ -1,0 +1,6 @@
+export function parseFilePaths(input: string): string[] {
+	return input
+		.replace(/\\/g, "/")
+		.split(/\r?\n/)
+		.filter((filePath) => filePath.length > 0);
+}

--- a/packages/repopo/src/filePaths.ts
+++ b/packages/repopo/src/filePaths.ts
@@ -1,6 +1,9 @@
+const WINDOWS_SEPARATOR = /\\/g;
+const LINE_BREAK = /\r?\n/;
+
 export function parseFilePaths(input: string): string[] {
 	return input
-		.replace(/\\/g, "/")
-		.split(/\r?\n/)
+		.replace(WINDOWS_SEPARATOR, "/")
+		.split(LINE_BREAK)
 		.filter((filePath) => filePath.length > 0);
 }

--- a/packages/repopo/src/perf.ts
+++ b/packages/repopo/src/perf.ts
@@ -13,7 +13,7 @@ export type PolicyAction = "check" | "resolve" | "handle";
  * @alpha
  */
 export interface PolicyHandlerPerfStats {
-	/** Number of non-empty candidate file paths supplied to the runner. */
+	/** Number of candidate file paths supplied to the runner. */
 	count: number;
 	/** Number of candidate files admitted past global exclusions. */
 	processed: number;

--- a/packages/repopo/src/perf.ts
+++ b/packages/repopo/src/perf.ts
@@ -13,7 +13,9 @@ export type PolicyAction = "check" | "resolve" | "handle";
  * @alpha
  */
 export interface PolicyHandlerPerfStats {
+	/** Number of non-empty candidate file paths supplied to the runner. */
 	count: number;
+	/** Number of candidate files admitted past global exclusions. */
 	processed: number;
 	data: Map<PolicyAction, Map<PolicyName, number>>;
 }

--- a/packages/repopo/src/runner.ts
+++ b/packages/repopo/src/runner.ts
@@ -112,6 +112,8 @@ export class PolicyRunner {
 			return;
 		}
 
+		this.perfStats.processed++;
+
 		const matchingPolicies = this.policies.filter((policy) =>
 			policy.match.test(relPath),
 		);

--- a/packages/repopo/test/filePaths.test.ts
+++ b/packages/repopo/test/filePaths.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { parseFilePaths } from "../src/filePaths.js";
+
+describe("parseFilePaths", () => {
+	it("returns an empty array for empty input", () => {
+		expect(parseFilePaths("")).toEqual([]);
+	});
+
+	it("drops a trailing LF", () => {
+		expect(parseFilePaths("packages/repopo/src/index.ts\n")).toEqual([
+			"packages/repopo/src/index.ts",
+		]);
+	});
+
+	it("drops a trailing CRLF", () => {
+		expect(parseFilePaths("packages/repopo/src/index.ts\r\n")).toEqual([
+			"packages/repopo/src/index.ts",
+		]);
+	});
+
+	it("removes blank records and normalizes Windows separators", () => {
+		expect(
+			parseFilePaths("packages\\repopo\\src\\index.ts\r\n\r\npackages\\repopo\\test\\index.ts"),
+		).toEqual([
+			"packages/repopo/src/index.ts",
+			"packages/repopo/test/index.ts",
+		]);
+	});
+});

--- a/packages/repopo/test/filePaths.test.ts
+++ b/packages/repopo/test/filePaths.test.ts
@@ -21,7 +21,9 @@ describe("parseFilePaths", () => {
 
 	it("removes blank records and normalizes Windows separators", () => {
 		expect(
-			parseFilePaths("packages\\repopo\\src\\index.ts\r\n\r\npackages\\repopo\\test\\index.ts"),
+			parseFilePaths(
+				"packages\\repopo\\src\\index.ts\r\n\r\npackages\\repopo\\test\\index.ts",
+			),
 		).toEqual([
 			"packages/repopo/src/index.ts",
 			"packages/repopo/test/index.ts",

--- a/packages/repopo/test/perf.test.ts
+++ b/packages/repopo/test/perf.test.ts
@@ -47,15 +47,15 @@ describe("Performance Utilities", () => {
 			const logger = createMockLogger();
 
 			const stats: PolicyHandlerPerfStats = {
-				count: 10,
-				processed: 7,
+				count: 3,
+				processed: 2,
 				data: new Map(),
 			};
 
 			logStats(stats, logger);
 
 			expect(logger.log).toHaveBeenCalledWith(
-				"Statistics: 7 files processed, 3 excluded, 10 total",
+				"Statistics: 2 files processed, 1 excluded, 3 total",
 			);
 		});
 

--- a/packages/repopo/test/runner.test.ts
+++ b/packages/repopo/test/runner.test.ts
@@ -30,12 +30,14 @@ describe("PolicyRunner", () => {
 			const results = await run(() => runner.run([]));
 			expect(results.results).toEqual([]);
 			expect(results.perfStats.count).toBe(0);
+			expect(results.perfStats.processed).toBe(0);
 		});
 
 		it("should count all processed files", async () => {
 			const runner = new PolicyRunner(makeRunnerOptions());
 			const results = await run(() => runner.run(["a.txt", "b.txt", "c.txt"]));
 			expect(results.perfStats.count).toBe(3);
+			expect(results.perfStats.processed).toBe(3);
 		});
 
 		it("should return no results when all policies pass", async () => {
@@ -79,6 +81,35 @@ describe("PolicyRunner", () => {
 			);
 			expect(handlerCalled).toBe(false);
 			expect(results.results).toEqual([]);
+			expect(results.perfStats.count).toBe(1);
+			expect(results.perfStats.processed).toBe(0);
+		});
+
+		it("should only process files admitted past global exclusions", async () => {
+			const handledFiles: string[] = [];
+			const testPolicy = policy({
+				name: "TestPolicy",
+				description: "Test",
+				match: /\.txt$/,
+				handler: async ({ file }) => {
+					handledFiles.push(file);
+					return true;
+				},
+			});
+
+			const runner = new PolicyRunner(
+				makeRunnerOptions({
+					policies: [testPolicy],
+					excludeFromAll: [/generated/],
+				}),
+			);
+
+			const results = await run(() =>
+				runner.run(["file.txt", "generated/output.txt", "README.md"]),
+			);
+			expect(handledFiles).toEqual(["file.txt"]);
+			expect(results.perfStats.count).toBe(3);
+			expect(results.perfStats.processed).toBe(2);
 		});
 
 		it("should exclude files matching per-policy exclusions", async () => {
@@ -165,6 +196,31 @@ describe("PolicyRunner", () => {
 			await run(() => runner.run(["file.txt", "file.mjs"]));
 			expect(txtCalled).toEqual(["file.txt"]);
 			expect(jsCalled).toEqual(["file.mjs"]);
+		});
+
+		it("should count a file once when duplicate policy instances match it", async () => {
+			let handlerCalls = 0;
+			const duplicatePolicy: PolicyShape = {
+				name: "DuplicatePolicy",
+				description: "Matches the same file twice",
+				match: /\.txt$/,
+				handler: async () => {
+					handlerCalls++;
+					return true;
+				},
+			};
+
+			const runner = new PolicyRunner(
+				makeRunnerOptions({
+					policies: [policy(duplicatePolicy), policy(duplicatePolicy)],
+				}),
+			);
+
+			const results = await run(() => runner.run(["file.txt"]));
+			expect(handlerCalls).toBe(2);
+			expect(results.results).toEqual([]);
+			expect(results.perfStats.count).toBe(1);
+			expect(results.perfStats.processed).toBe(1);
 		});
 	});
 

--- a/packages/repopo/test/runner.test.ts
+++ b/packages/repopo/test/runner.test.ts
@@ -136,6 +136,8 @@ describe("PolicyRunner", () => {
 			const results = await run(() => runner.run(["generated/output.txt"]));
 			expect(handlerCalled).toBe(false);
 			expect(results.results).toEqual([]);
+			expect(results.perfStats.count).toBe(1);
+			expect(results.perfStats.processed).toBe(1);
 		});
 
 		it("should log verbose messages for exclusions", async () => {


### PR DESCRIPTION
## Summary

- normalize Git and stdin file lists before policy processing
- count processed files once after global exclusions
- cover empty, excluded, mixed, and duplicate-policy inputs

Fixes #777