### PR TITLE
fix(repopo): harden policy execution errors

### DIFF
--- a/.changeset/steady-policies-continue.md
+++ b/.changeset/steady-policies-continue.md
@@ -1,0 +1,5 @@
+---
+"repopo": patch
+---
+
+Report unexpected policy execution errors for the affected file and continue checking remaining files.

--- a/packages/repopo/src/runner.ts
+++ b/packages/repopo/src/runner.ts
@@ -176,9 +176,14 @@ export class PolicyRunner {
 
 			this.results.push(fileResult);
 		} catch (error: unknown) {
-			throw new Error(
-				`Error executing policy '${policy.name}' for file '${relPath}': ${error}`,
-			);
+			const message = error instanceof Error ? error.message : String(error);
+			this.results.push({
+				file: relPath,
+				policy: policy.name,
+				outcome: {
+					error: `System Error: Error executing policy '${policy.name}' for file '${relPath}': ${message}`,
+				},
+			});
 		}
 	}
 

--- a/packages/repopo/test/runner.test.ts
+++ b/packages/repopo/test/runner.test.ts
@@ -494,13 +494,18 @@ describe("PolicyRunner", () => {
 	});
 
 	describe("error handling", () => {
-		it("should throw with context when handler throws", async () => {
+		it("should report a system error and continue when a handler throws", async () => {
+			const processedFiles: string[] = [];
 			const testPolicy = policy({
 				name: "ThrowPolicy",
 				description: "Throws",
 				match: /\.txt$/,
-				handler: async () => {
-					throw new Error("handler boom");
+				handler: async ({ file }) => {
+					processedFiles.push(file);
+					if (file === "bad.txt") {
+						throw new Error("handler boom");
+					}
+					return true;
 				},
 			});
 
@@ -508,9 +513,19 @@ describe("PolicyRunner", () => {
 				makeRunnerOptions({ policies: [testPolicy] }),
 			);
 
-			await expect(run(() => runner.run(["file.txt"]))).rejects.toThrow(
-				/Error executing policy 'ThrowPolicy'/,
-			);
+			const results = await run(() => runner.run(["bad.txt", "good.txt"]));
+
+			expect(processedFiles).toEqual(["bad.txt", "good.txt"]);
+			expect(results.results).toEqual([
+				{
+					file: "bad.txt",
+					policy: "ThrowPolicy",
+					outcome: {
+						error:
+							"System Error: Error executing policy 'ThrowPolicy' for file 'bad.txt': handler boom",
+					},
+				},
+			]);
 		});
 	});
 


### PR DESCRIPTION
## Summary

- contain unexpected exceptions at the individual policy/file execution boundary
- report the affected policy and file as a clear `System Error`
- continue processing remaining files after a policy handler throws
- add regression coverage and a patch changeset for `repopo`

Closes #667

## Validation

- `pnpm nx run repopo:test:vitest -- --run test/runner.test.ts`
- `pnpm nx run repopo:format`
- `pnpm nx run repopo:lint`
- `pnpm nx run repopo:build`
- `pnpm nx run repopo:test` (66 files, 856 tests)
- `pnpm run ci:check`
