### PR TITLE
fix(repopo): PolicyRunner state isolation

### DIFF
--- a/.changeset/repopo-isolate-runner-state.md
+++ b/.changeset/repopo-isolate-runner-state.md
@@ -1,0 +1,5 @@
+---
+"repopo": patch
+---
+
+Isolate policy run results and performance statistics across sequential and concurrent `PolicyRunner` invocations.

--- a/packages/repopo-docs/src/content/docs/api/classes/PolicyRunner.md
+++ b/packages/repopo-docs/src/content/docs/api/classes/PolicyRunner.md
@@ -5,7 +5,7 @@ prev: false
 title: "PolicyRunner"
 ---
 
-Defined in: [runner.ts:81](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L81)
+Defined in: [runner.ts:86](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L86)
 
 Runs configured policies against files and collects results.
 
@@ -19,7 +19,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **new PolicyRunner**(`options`): `PolicyRunner`
 
-Defined in: [runner.ts:92](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L92)
+Defined in: [runner.ts:94](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L94)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -41,7 +41,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **run**(`filePaths`): `Operation`\<[`PolicyRunResults`](/api/interfaces/policyrunresults/)\>
 
-Defined in: [runner.ts:101](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L101)
+Defined in: [runner.ts:103](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L103)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.

--- a/packages/repopo-docs/src/content/docs/api/interfaces/PolicyRunnerOptions.md
+++ b/packages/repopo-docs/src/content/docs/api/interfaces/PolicyRunnerOptions.md
@@ -5,7 +5,7 @@ prev: false
 title: "PolicyRunnerOptions"
 ---
 
-Defined in: [runner.ts:68](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L68)
+Defined in: [runner.ts:73](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L73)
 
 Options for configuring a [PolicyRunner](/api/classes/policyrunner/).
 
@@ -19,7 +19,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **excludeFromAll**: [`RegExp`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp)[]
 
-Defined in: [runner.ts:70](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L70)
+Defined in: [runner.ts:75](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L75)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -31,7 +31,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **excludePoliciesForFiles**: [`ExcludedPolicyFileMap`](/api/type-aliases/excludedpolicyfilemap/)
 
-Defined in: [runner.ts:71](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L71)
+Defined in: [runner.ts:76](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L76)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -43,7 +43,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **gitRoot**: `string`
 
-Defined in: [runner.ts:72](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L72)
+Defined in: [runner.ts:77](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L77)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -55,7 +55,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > `optional` **logger?**: [`Pick`](https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys)\<`Logger`, `"verbose"`\>
 
-Defined in: [runner.ts:74](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L74)
+Defined in: [runner.ts:79](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L79)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -67,7 +67,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **policies**: [`PolicyInstance`](/api/type-aliases/policyinstance/)[]
 
-Defined in: [runner.ts:69](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L69)
+Defined in: [runner.ts:74](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L74)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.
@@ -79,7 +79,7 @@ This API should not be used in production and may be trimmed from a public relea
 
 > **resolve**: `boolean`
 
-Defined in: [runner.ts:73](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L73)
+Defined in: [runner.ts:78](https://github.com/tylerbutler/tools-monorepo/blob/main/packages/repopo/src/runner.ts#L78)
 
 :::caution[Alpha]
 This API should not be used in production and may be trimmed from a public release.

--- a/packages/repopo/src/runner.ts
+++ b/packages/repopo/src/runner.ts
@@ -61,6 +61,11 @@ export interface PolicyRunResults {
 	perfStats: PolicyHandlerPerfStats;
 }
 
+interface PolicyRunState {
+	results: PolicyFileResult[];
+	perfStats: PolicyHandlerPerfStats;
+}
+
 /**
  * Options for configuring a {@link PolicyRunner}.
  * @alpha
@@ -86,9 +91,6 @@ export class PolicyRunner {
 	private readonly resolve: boolean;
 	private readonly logger: Pick<Logger, "verbose"> | undefined;
 
-	private readonly results: PolicyFileResult[] = [];
-	private readonly perfStats: PolicyHandlerPerfStats = newPerfStats();
-
 	public constructor(options: PolicyRunnerOptions) {
 		this.policies = options.policies;
 		this.excludeFromAll = options.excludeFromAll;
@@ -99,20 +101,28 @@ export class PolicyRunner {
 	}
 
 	public *run(filePaths: string[]): Operation<PolicyRunResults> {
+		const state: PolicyRunState = {
+			results: [],
+			perfStats: newPerfStats(),
+		};
+
 		for (const filePath of filePaths) {
-			yield* this.checkOrExcludeFile(filePath);
+			yield* this.checkOrExcludeFile(filePath, state);
 		}
 
 		return {
-			results: this.results,
-			perfStats: this.perfStats,
+			results: state.results,
+			perfStats: state.perfStats,
 		};
 	}
 
-	private *checkOrExcludeFile(relPath: string): Operation<void> {
-		this.perfStats.count++;
+	private *checkOrExcludeFile(
+		relPath: string,
+		state: PolicyRunState,
+	): Operation<void> {
+		state.perfStats.count++;
 		try {
-			yield* this.routeToPolicies(relPath);
+			yield* this.routeToPolicies(relPath, state);
 		} catch (error: unknown) {
 			throw new Error(
 				`Error routing ${relPath} to handler: ${error}\nStack:\n${(error as Error).stack}`,
@@ -120,7 +130,10 @@ export class PolicyRunner {
 		}
 	}
 
-	private *routeToPolicies(relPath: string): Operation<void> {
+	private *routeToPolicies(
+		relPath: string,
+		state: PolicyRunState,
+	): Operation<void> {
 		if (this.excludeFromAll.some((regex) => matches(regex, relPath))) {
 			this.logger?.verbose(`Excluded all handlers: ${relPath}`);
 			return;
@@ -131,7 +144,7 @@ export class PolicyRunner {
 		);
 		yield* all(
 			matchingPolicies.map((policy) => {
-				return this.runPolicyOnFile(relPath, policy);
+				return this.runPolicyOnFile(relPath, policy, state);
 			}),
 		);
 	}
@@ -139,6 +152,7 @@ export class PolicyRunner {
 	private *runPolicyOnFile(
 		relPath: string,
 		policy: PolicyInstance,
+		state: PolicyRunState,
 	): Operation<void> {
 		if (this.isPolicyExcluded(relPath, policy)) {
 			this.logger?.verbose(`Excluded from '${policy.name}' policy: ${relPath}`);
@@ -146,7 +160,7 @@ export class PolicyRunner {
 		}
 
 		try {
-			const result = yield* this.executePolicyHandler(relPath, policy);
+			const result = yield* this.executePolicyHandler(relPath, policy, state);
 
 			// Success — nothing to report
 			if (result === true) {
@@ -170,11 +184,12 @@ export class PolicyRunner {
 					relPath,
 					policy,
 					policy.resolver,
+					state,
 				);
 				fileResult.resolution = resolution;
 			}
 
-			this.results.push(fileResult);
+			state.results.push(fileResult);
 		} catch (error: unknown) {
 			throw new Error(
 				`Error executing policy '${policy.name}' for file '${relPath}': ${error}`,
@@ -193,13 +208,14 @@ export class PolicyRunner {
 	private *executePolicyHandler(
 		relPath: string,
 		policy: PolicyInstance,
+		state: PolicyRunState,
 	): Operation<PolicyHandlerResult> {
-		const { resolve, gitRoot, perfStats } = this;
+		const { resolve, gitRoot } = this;
 
 		const result = yield* runWithPerf(
 			policy.name,
 			"handle",
-			perfStats,
+			state.perfStats,
 			function* () {
 				const args = {
 					file: relPath,
@@ -236,22 +252,28 @@ export class PolicyRunner {
 		relPath: string,
 		policy: PolicyInstance,
 		resolver: PolicyStandaloneResolver,
+		state: PolicyRunState,
 	): Operation<PolicyFixResult> {
-		const { gitRoot, perfStats } = this;
+		const { gitRoot } = this;
 
-		return yield* runWithPerf(policy.name, "resolve", perfStats, function* () {
-			const result = resolver({
-				file: relPath,
-				root: gitRoot,
-				config: policy.config,
-			});
-			if (result instanceof Promise) {
-				return yield* call(() => result);
-			}
-			if (isOperation<PolicyFixResult>(result)) {
-				return yield* result;
-			}
-			throw new Error(`Unexpected resolver result type: ${typeof result}`);
-		});
+		return yield* runWithPerf(
+			policy.name,
+			"resolve",
+			state.perfStats,
+			function* () {
+				const result = resolver({
+					file: relPath,
+					root: gitRoot,
+					config: policy.config,
+				});
+				if (result instanceof Promise) {
+					return yield* call(() => result);
+				}
+				if (isOperation<PolicyFixResult>(result)) {
+					return yield* result;
+				}
+				throw new Error(`Unexpected resolver result type: ${typeof result}`);
+			},
+		);
 	}
 }

--- a/packages/repopo/test/runner.test.ts
+++ b/packages/repopo/test/runner.test.ts
@@ -1,4 +1,4 @@
-import { run } from "effection";
+import { all, run } from "effection";
 import { describe, expect, it, vi } from "vitest";
 
 import { policy } from "../src/makePolicy.js";
@@ -51,6 +51,87 @@ describe("PolicyRunner", () => {
 			);
 			const results = await run(() => runner.run(["file.txt"]));
 			expect(results.results).toEqual([]);
+		});
+
+		it("should use fresh state when a runner is reused", async () => {
+			const failingPolicy = policy({
+				name: "FailPolicy",
+				description: "Always fails",
+				match: /\.txt$/,
+				handler: async (): Promise<PolicyError> => ({
+					error: "Something went wrong",
+				}),
+			});
+			const options = makeRunnerOptions({ policies: [failingPolicy] });
+			const runner = new PolicyRunner(options);
+
+			await run(() => runner.run(["first.txt"]));
+			const reusedResult = await run(() => runner.run(["second.txt"]));
+			const freshResult = await run(() =>
+				new PolicyRunner(options).run(["second.txt"]),
+			);
+
+			expect(reusedResult.results).toEqual(freshResult.results);
+			expect(reusedResult.perfStats.count).toBe(freshResult.perfStats.count);
+			expect(reusedResult.results.map(({ file }) => file)).toEqual([
+				"second.txt",
+			]);
+		});
+
+		it("should not mutate a previously returned result after reuse", async () => {
+			const failingPolicy = policy({
+				name: "FailPolicy",
+				description: "Always fails",
+				match: /\.txt$/,
+				handler: async (): Promise<PolicyError> => ({
+					error: "Something went wrong",
+				}),
+			});
+			const runner = new PolicyRunner(
+				makeRunnerOptions({ policies: [failingPolicy] }),
+			);
+
+			const firstResult = await run(() => runner.run(["first.txt"]));
+			const firstResultsSnapshot = structuredClone(firstResult.results);
+			const firstPerfSnapshot = structuredClone(firstResult.perfStats);
+			const secondResult = await run(() => runner.run(["second.txt"]));
+
+			expect(firstResult.results).toEqual(firstResultsSnapshot);
+			expect(firstResult.perfStats).toEqual(firstPerfSnapshot);
+			expect(firstResult.results).not.toBe(secondResult.results);
+			expect(firstResult.perfStats).not.toBe(secondResult.perfStats);
+		});
+
+		it("should isolate state between concurrent runs", async () => {
+			const failingPolicy = policy({
+				name: "FailPolicy",
+				description: "Always fails",
+				match: /\.txt$/,
+				handler: async (): Promise<PolicyError> => ({
+					error: "Something went wrong",
+				}),
+			});
+			const runner = new PolicyRunner(
+				makeRunnerOptions({ policies: [failingPolicy] }),
+			);
+
+			const [firstResult, secondResult] = await run(function* () {
+				return yield* all([
+					runner.run(["first.txt"]),
+					runner.run(["second.txt"]),
+				]);
+			});
+
+			expect(firstResult.results.map(({ file }) => file)).toEqual([
+				"first.txt",
+			]);
+			expect(secondResult.results.map(({ file }) => file)).toEqual([
+				"second.txt",
+			]);
+			expect(firstResult.perfStats.count).toBe(1);
+			expect(secondResult.perfStats.count).toBe(1);
+			expect(firstResult.results).not.toBe(secondResult.results);
+			expect(firstResult.perfStats).not.toBe(secondResult.perfStats);
 		});
 	});
 


### PR DESCRIPTION
## Summary

- create fresh result and performance state for every `PolicyRunner.run()` invocation
- thread invocation-local state through policy routing, handler execution, and resolution
- guarantee that sequential reuse and concurrent calls cannot mutate or share returned results
- add regression coverage for runner reuse, earlier-result isolation, and concurrent execution
- refresh generated API documentation source links after the runner line changes
- add a patch changeset for `repopo`

Closes #775.

## Validation

- `pnpm nx run repopo:test:vitest -- --run test/runner.test.ts` — 26 tests passed
- `pnpm nx run repopo:test:vitest -- --run` — 66 files, 859 tests passed
- `pnpm nx run repopo:build:compile`
- `pnpm nx run repopo:check:format`
- `pnpm nx run repopo:lint`
- `pnpm nx run repopo-docs:build:site`
- `pnpm nx run repopo-docs:check:astro`

`./packages/repopo/bin/dev.js check --fix` was also attempted, but OCLIF command discovery failed on existing `check-native.ts`, `check.ts`, and `list.ts` type-resolution errors before the command could run.
