### PR TITLE
Fix repopo policy path resolution

### DIFF
--- a/.changeset/repopo-root-relative-paths.md
+++ b/.changeset/repopo-root-relative-paths.md
@@ -1,0 +1,5 @@
+---
+"repopo": patch
+---
+
+Resolve built-in policy filesystem operations from the repository root when policy file paths are repository-relative.

--- a/packages/repopo/src/policies/ConditionalScripts.ts
+++ b/packages/repopo/src/policies/ConditionalScripts.ts
@@ -1,4 +1,5 @@
 import jsonfile from "jsonfile";
+import { resolve as resolvePath } from "pathe";
 import type { PackageJson } from "type-fest";
 import { definePackagePolicy } from "../policyDefiners/definePackagePolicy.js";
 
@@ -216,7 +217,7 @@ export const ConditionalScripts = definePackagePolicy<
 	name: POLICY_NAME,
 	description:
 		"Validates that if certain scripts exist, other required scripts must also exist.",
-	handler: async (json, { file, resolve, config }) => {
+	handler: async (json, { file, root, resolve, config }) => {
 		if (config === undefined || config.rules.length === 0) {
 			return true;
 		}
@@ -235,7 +236,7 @@ export const ConditionalScripts = definePackagePolicy<
 			try {
 				const fixedScripts = await fixMissingScripts(
 					json,
-					file,
+					resolvePath(root, file),
 					validation.missingWithDefaults,
 					scripts,
 				);

--- a/packages/repopo/src/policies/ExactScripts.ts
+++ b/packages/repopo/src/policies/ExactScripts.ts
@@ -1,4 +1,5 @@
 import jsonfile from "jsonfile";
+import { resolve as resolvePath } from "pathe";
 import type { PackageJson } from "type-fest";
 import { definePackagePolicy } from "../policyDefiners/definePackagePolicy.js";
 
@@ -128,7 +129,7 @@ export const ExactScripts = definePackagePolicy<
 	name: POLICY_NAME,
 	description:
 		"Validates that scripts exist and have exact content in package.json.",
-	handler: async (json, { file, resolve, config }) => {
+	handler: async (json, { file, root, resolve, config }) => {
 		if (config === undefined || Object.keys(config.scripts).length === 0) {
 			return true;
 		}
@@ -150,7 +151,7 @@ export const ExactScripts = definePackagePolicy<
 			try {
 				const fixedScripts = await fixScripts(
 					json,
-					file,
+					resolvePath(root, file),
 					scriptsToFix,
 					config.scripts,
 					scripts,

--- a/packages/repopo/src/policies/PackageEsmType.ts
+++ b/packages/repopo/src/policies/PackageEsmType.ts
@@ -1,4 +1,5 @@
 import jsonfile from "jsonfile";
+import { resolve as resolvePath } from "pathe";
 import type { PackageJson } from "type-fest";
 import type { PolicyFailure, PolicyFixResult } from "../policy.js";
 import { definePackagePolicy } from "../policyDefiners/definePackagePolicy.js";
@@ -302,6 +303,7 @@ function buildErrorMessage(
 async function applyFix(
 	json: PackageJson,
 	file: string,
+	root: string,
 	expectedType: "module" | "commonjs",
 	failResult: PolicyFailure,
 ): Promise<PolicyFixResult> {
@@ -312,8 +314,9 @@ async function applyFix(
 
 	try {
 		json.type = expectedType;
-		const indent = await detectIndentation(file);
-		await writeJson(file, json, { spaces: indent });
+		const filePath = resolvePath(root, file);
+		const indent = await detectIndentation(filePath);
+		await writeJson(filePath, json, { spaces: indent });
 		fixResult.resolved = true;
 	} catch {
 		fixResult.resolved = false;
@@ -362,7 +365,7 @@ export const PackageEsmType = definePackagePolicy<
 	name: "PackageEsmType",
 	description:
 		"Ensures the type field in package.json correctly indicates ESM or CommonJS module format.",
-	handler: async (json, { file, config, resolve }) => {
+	handler: async (json, { file, root, config, resolve }) => {
 		// If no config provided, skip validation
 		if (config === undefined) {
 			return true;
@@ -414,7 +417,7 @@ export const PackageEsmType = definePackagePolicy<
 		};
 
 		if (resolve) {
-			return applyFix(json, file, expectedType, failResult);
+			return applyFix(json, file, root, expectedType, failResult);
 		}
 
 		return failResult;

--- a/packages/repopo/src/policies/PackageJsonProperties.ts
+++ b/packages/repopo/src/policies/PackageJsonProperties.ts
@@ -2,6 +2,7 @@ import { defu } from "defu";
 import { call } from "effection";
 import jsonfile from "jsonfile";
 import diff from "microdiff";
+import { resolve as resolvePath } from "pathe";
 import type { PackageJson } from "type-fest";
 import type { PolicyFailure, PolicyFixResult } from "../policy.js";
 import { definePackagePolicy } from "../policyDefiners/definePackagePolicy.js";
@@ -32,7 +33,7 @@ export const PackageJsonProperties = definePackagePolicy<
 	name: "PackageJsonProperties",
 	description:
 		"Ensures package.json files contain required properties with correct values.",
-	handler: function* (json, { file, config, resolve }) {
+	handler: function* (json, { file, root, config, resolve }) {
 		if (config === undefined) {
 			return true;
 		}
@@ -62,7 +63,9 @@ export const PackageJsonProperties = definePackagePolicy<
 					resolved: false,
 				};
 
-				yield* call(() => writeJson(file, merged, { spaces: "\t" }));
+				yield* call(() =>
+					writeJson(resolvePath(root, file), merged, { spaces: "\t" }),
+				);
 
 				fixResult.resolved = true;
 				return fixResult;

--- a/packages/repopo/src/policies/PackageJsonRepoDirectoryProperty.ts
+++ b/packages/repopo/src/policies/PackageJsonRepoDirectoryProperty.ts
@@ -31,7 +31,8 @@ export const PackageJsonRepoDirectoryProperty = definePackagePolicy<
 			resolved: false,
 		};
 
-		const pkgDir = path.dirname(file);
+		const packageJsonPath = path.resolve(root, file);
+		const pkgDir = path.dirname(packageJsonPath);
 		const maybeDir = path.relative(root, pkgDir);
 		const relativePkgDir = maybeDir === "" ? undefined : maybeDir;
 
@@ -41,7 +42,7 @@ export const PackageJsonRepoDirectoryProperty = definePackagePolicy<
 		) {
 			if (resolve) {
 				try {
-					updatePackageJsonFile(file, (pkgJson) => {
+					updatePackageJsonFile(packageJsonPath, (pkgJson) => {
 						assert(typeof pkgJson.repository === "object");
 						if (relativePkgDir === undefined) {
 							delete pkgJson.repository.directory;

--- a/packages/repopo/src/policies/PackageLicense.ts
+++ b/packages/repopo/src/policies/PackageLicense.ts
@@ -128,8 +128,7 @@ export const PackageLicense = definePackagePolicy<
 		}
 
 		const packageName = json.name ?? "unknown";
-		// file is an absolute path, get the directory containing package.json
-		const packageDir = path.dirname(file);
+		const packageDir = path.dirname(path.resolve(root, file));
 		const packageLicensePath = path.join(packageDir, licenseFileName);
 		const rootLicensePath = path.join(root, licenseFileName);
 

--- a/packages/repopo/src/policies/PackagePrivateField.ts
+++ b/packages/repopo/src/policies/PackagePrivateField.ts
@@ -1,4 +1,5 @@
 import jsonfile from "jsonfile";
+import { resolve as resolvePath } from "pathe";
 import picomatch from "picomatch";
 import type { PackageJson } from "type-fest";
 import type { PolicyFailure, PolicyFixResult } from "../policy.js";
@@ -214,7 +215,7 @@ export const PackagePrivateField = definePackagePolicy<
 	name: "PackagePrivateField",
 	description:
 		"Enforces the private field in package.json based on package scope or name patterns.",
-	handler: async (json, { file, config, resolve }) => {
+	handler: async (json, { file, root, config, resolve }) => {
 		// If no config provided, skip validation
 		if (config === undefined) {
 			return true;
@@ -274,7 +275,7 @@ export const PackagePrivateField = definePackagePolicy<
 					delete json.private;
 				}
 
-				await writeJson(file, json, { spaces: "\t" });
+				await writeJson(resolvePath(root, file), json, { spaces: "\t" });
 				fixResult.resolved = true;
 			} catch {
 				fixResult.resolved = false;

--- a/packages/repopo/src/policies/PackageReadme.ts
+++ b/packages/repopo/src/policies/PackageReadme.ts
@@ -286,7 +286,7 @@ export const PackageReadme = definePackagePolicy<
 	name: "PackageReadme",
 	description:
 		"Ensures each package has a README.md file with proper title and required content.",
-	handler: async (json, { file, resolve, config }) => {
+	handler: async (json, { file, root, resolve, config }) => {
 		const skipPrivate = config?.skipPrivate ?? true;
 		const requireMatchingTitle = config?.requireMatchingTitle ?? true;
 		const requiredContent = config?.requiredContent;
@@ -297,7 +297,7 @@ export const PackageReadme = definePackagePolicy<
 		}
 
 		const packageName = json.name ?? "unknown";
-		const packageDir = path.dirname(file);
+		const packageDir = path.dirname(path.resolve(root, file));
 		const readmePath = path.join(packageDir, "README.md");
 
 		// Check if README exists

--- a/packages/repopo/src/policies/PackageScripts.ts
+++ b/packages/repopo/src/policies/PackageScripts.ts
@@ -1,4 +1,5 @@
 import jsonfile from "jsonfile";
+import { resolve as resolvePath } from "pathe";
 import type { PackageJson } from "type-fest";
 import { definePackagePolicy } from "../policyDefiners/definePackagePolicy.js";
 
@@ -709,7 +710,7 @@ export const PackageScripts = definePackagePolicy<
 	name: "PackageScripts",
 	description:
 		"Validates package.json scripts based on configurable rules including required scripts, exact content, and conditional requirements.",
-	handler: async (json, { file, resolve, config }) => {
+	handler: async (json, { file, root, resolve, config }) => {
 		if (config === undefined) {
 			return true;
 		}
@@ -737,7 +738,7 @@ export const PackageScripts = definePackagePolicy<
 
 			try {
 				await jsonfile.writeFile(
-					file,
+					resolvePath(root, file),
 					{ ...json, scripts: updatedScripts },
 					{ spaces: 2 },
 				);

--- a/packages/repopo/src/policies/PackageTestScripts.ts
+++ b/packages/repopo/src/policies/PackageTestScripts.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { dirname, join } from "pathe";
+import { dirname, join, resolve as resolvePath } from "pathe";
 import type { PackageJson } from "type-fest";
 import type { PolicyFailure } from "../policy.js";
 import { definePackagePolicy } from "../policyDefiners/definePackagePolicy.js";
@@ -217,7 +217,7 @@ export const PackageTestScripts = definePackagePolicy<
 	name: "PackageTestScripts",
 	description:
 		"Ensures packages have test scripts when test directories or test framework dependencies exist.",
-	handler: async (json, { file, config }) => {
+	handler: async (json, { file, root, config }) => {
 		// If no config provided, skip validation
 		if (config === undefined) {
 			return true;
@@ -232,7 +232,7 @@ export const PackageTestScripts = definePackagePolicy<
 		const testDirectories = config.testDirectories ?? [];
 		const testDependencies = config.testDependencies ?? [];
 		const requiredScripts = config.requiredScripts ?? ["test"];
-		const packageDir = dirname(file);
+		const packageDir = dirname(resolvePath(root, file));
 		const devDeps = json.devDependencies as Record<string, string> | undefined;
 
 		// Check if tests are expected based on what's configured

--- a/packages/repopo/src/policies/RequiredScripts.ts
+++ b/packages/repopo/src/policies/RequiredScripts.ts
@@ -1,4 +1,5 @@
 import jsonfile from "jsonfile";
+import { resolve as resolvePath } from "pathe";
 import type { PackageJson } from "type-fest";
 import { definePackagePolicy } from "../policyDefiners/definePackagePolicy.js";
 
@@ -161,7 +162,7 @@ export const RequiredScripts = definePackagePolicy<
 >({
 	name: POLICY_NAME,
 	description: "Validates that required scripts exist in package.json.",
-	handler: async (json, { file, resolve, config }) => {
+	handler: async (json, { file, root, resolve, config }) => {
 		if (config === undefined || config.scripts.length === 0) {
 			return true;
 		}
@@ -179,7 +180,7 @@ export const RequiredScripts = definePackagePolicy<
 			try {
 				const fixedScripts = await fixMissingScripts(
 					json,
-					file,
+					resolvePath(root, file),
 					validation.missingWithDefaults,
 					scripts,
 				);

--- a/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts
+++ b/packages/repopo/src/policyDefiners/defineFileHeaderPolicy.ts
@@ -1,7 +1,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { EOL as newline } from "node:os";
 import { call } from "effection";
-import { extname } from "pathe";
+import { extname, resolve as resolvePath } from "pathe";
 import type { PolicyFailure, PolicyFixResult, PolicyShape } from "../policy.js";
 
 const trailingSpaces = /\s*\\r\?\\n/;
@@ -133,7 +133,7 @@ export function defineFileHeaderPolicy(
 		name,
 		description,
 		match: config.match,
-		handler: function* ({ file, resolve, config: policyConfig }) {
+		handler: function* ({ file, root, resolve, config: policyConfig }) {
 			if (policyConfig === undefined) {
 				return true;
 			}
@@ -147,7 +147,10 @@ export function defineFileHeaderPolicy(
 
 			// TODO: Consider reading only the first 512B or so since headers are typically
 			// at the beginning of the file.
-			const content = yield* call(() => readFile(file, { encoding: "utf8" }));
+			const filePath = resolvePath(root, file);
+			const content = yield* call(() =>
+				readFile(filePath, { encoding: "utf8" }),
+			);
 			const failed = !regex.test(content);
 
 			if (failed) {
@@ -157,7 +160,7 @@ export function defineFileHeaderPolicy(
 			if (failed) {
 				if (resolve) {
 					const newContent = config.replacer(content, policyConfig);
-					yield* call(() => writeFile(file, newContent));
+					yield* call(() => writeFile(filePath, newContent));
 
 					const fixResult: PolicyFixResult = {
 						...failResult,

--- a/packages/repopo/test/defineFileHeaderPolicy.test.ts
+++ b/packages/repopo/test/defineFileHeaderPolicy.test.ts
@@ -83,7 +83,7 @@ describe("defineFileHeaderPolicy", () => {
 			});
 
 			const result = (await runHandler(policy.handler, {
-				file: testFile,
+				file: "test.ts",
 				root: testDir,
 				resolve: false,
 				config: { headerText: "Copyright 2025" },
@@ -112,7 +112,7 @@ describe("defineFileHeaderPolicy", () => {
 			});
 
 			const result = await runHandler(policy.handler, {
-				file: testFile,
+				file: "test.ts",
 				root: testDir,
 				resolve: false,
 				config: undefined,
@@ -142,7 +142,7 @@ describe("defineFileHeaderPolicy", () => {
 			});
 
 			const result = (await runHandler(policy.handler, {
-				file: testFile,
+				file: "test.ts",
 				root: testDir,
 				resolve: false,
 				config: { headerText: "Copyright 2025" },
@@ -172,7 +172,7 @@ describe("defineFileHeaderPolicy", () => {
 			});
 
 			const result = (await runHandler(policy.handler, {
-				file: testFile,
+				file: "test.ts",
 				root: testDir,
 				resolve: true,
 				config: { headerText },
@@ -207,7 +207,7 @@ describe("defineFileHeaderPolicy", () => {
 			});
 
 			await runHandler(policy.handler, {
-				file: testFile,
+				file: "test.ts",
 				root: testDir,
 				resolve: false,
 				config: { headerText: "Copyright 2025" },
@@ -239,7 +239,7 @@ describe("defineFileHeaderPolicy", () => {
 			});
 
 			await runHandler(policy.handler, {
-				file: testFile,
+				file: "test.ts",
 				root: testDir,
 				resolve: true,
 				config: { headerText },
@@ -271,7 +271,7 @@ describe("defineFileHeaderPolicy", () => {
 			});
 
 			const result = (await runHandler(policy.handler, {
-				file: testFile,
+				file: "test.ts",
 				root: testDir,
 				resolve: false,
 				config: { headerText: "Copyright" },
@@ -300,7 +300,7 @@ describe("defineFileHeaderPolicy", () => {
 			});
 
 			const result = (await runHandler(policy.handler, {
-				file: testFile,
+				file: "test.ts",
 				root: testDir,
 				resolve: false,
 				config: { headerText: "Copyright" },

--- a/packages/repopo/test/policies/ConditionalScripts.test.ts
+++ b/packages/repopo/test/policies/ConditionalScripts.test.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "pathe";
+import { join, relative } from "pathe";
 import type { PackageJson } from "type-fest";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -32,7 +32,7 @@ describe("ConditionalScripts policy", () => {
 		config?: ConditionalScriptsConfig,
 		resolve = false,
 	): PolicyArgs<typeof config> => ({
-		file: filePath,
+		file: relative(tempDir, filePath),
 		root: tempDir,
 		resolve,
 		config,

--- a/packages/repopo/test/policies/ExactScripts.test.ts
+++ b/packages/repopo/test/policies/ExactScripts.test.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "pathe";
+import { join, relative } from "pathe";
 import type { PackageJson } from "type-fest";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -32,7 +32,7 @@ describe("ExactScripts policy", () => {
 		config?: ExactScriptsConfig,
 		resolve = false,
 	): PolicyArgs<typeof config> => ({
-		file: filePath,
+		file: relative(tempDir, filePath),
 		root: tempDir,
 		resolve,
 		config,

--- a/packages/repopo/test/policies/PackageEsmType.test.ts
+++ b/packages/repopo/test/policies/PackageEsmType.test.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "pathe";
+import { join, relative } from "pathe";
 import type { PackageJson } from "type-fest";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -32,7 +32,7 @@ describe("PackageEsmType policy", () => {
 		config?: PackageEsmTypeConfig,
 		resolve = false,
 	): PolicyFunctionArguments<typeof config> => ({
-		file: filePath,
+		file: relative(tempDir, filePath),
 		root: tempDir,
 		resolve,
 		config,

--- a/packages/repopo/test/policies/PackageJsonProperties.test.ts
+++ b/packages/repopo/test/policies/PackageJsonProperties.test.ts
@@ -53,7 +53,7 @@ describe("PackageJsonProperties Policy", () => {
 			};
 
 			const result = await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: false,
 				config,
@@ -78,7 +78,7 @@ describe("PackageJsonProperties Policy", () => {
 			};
 
 			const result = (await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: false,
 				config,
@@ -105,7 +105,7 @@ describe("PackageJsonProperties Policy", () => {
 			};
 
 			const result = (await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: false,
 				config,
@@ -135,7 +135,7 @@ describe("PackageJsonProperties Policy", () => {
 			};
 
 			const result = (await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: false,
 				config,
@@ -156,7 +156,7 @@ describe("PackageJsonProperties Policy", () => {
 			await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
 			const result = await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: false,
 				config: undefined,
@@ -182,7 +182,7 @@ describe("PackageJsonProperties Policy", () => {
 			};
 
 			const result = (await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: false,
 				config,
@@ -207,7 +207,7 @@ describe("PackageJsonProperties Policy", () => {
 			};
 
 			const result = (await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: true,
 				config,
@@ -241,7 +241,7 @@ describe("PackageJsonProperties Policy", () => {
 			};
 
 			await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: true,
 				config,
@@ -270,7 +270,7 @@ describe("PackageJsonProperties Policy", () => {
 			};
 
 			await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: true,
 				config,
@@ -302,7 +302,7 @@ describe("PackageJsonProperties Policy", () => {
 			};
 
 			await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: false,
 				config,
@@ -327,7 +327,7 @@ describe("PackageJsonProperties Policy", () => {
 			};
 
 			await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: true,
 				config,
@@ -361,7 +361,7 @@ describe("PackageJsonProperties Policy", () => {
 			};
 
 			const result = (await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: false,
 				config,
@@ -387,7 +387,7 @@ describe("PackageJsonProperties Policy", () => {
 			};
 
 			const result = (await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: false,
 				config,
@@ -413,7 +413,7 @@ describe("PackageJsonProperties Policy", () => {
 			};
 
 			await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: true,
 				config,
@@ -445,7 +445,7 @@ describe("PackageJsonProperties Policy", () => {
 			};
 
 			const result = (await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: false,
 				config,
@@ -473,7 +473,7 @@ describe("PackageJsonProperties Policy", () => {
 			};
 
 			const result = (await runHandler(PackageJsonProperties.handler, {
-				file: packageJsonPath,
+				file: "package.json",
 				root: testDir,
 				resolve: false,
 				config,

--- a/packages/repopo/test/policies/PackageJsonRepoDirectoryProperty.test.ts
+++ b/packages/repopo/test/policies/PackageJsonRepoDirectoryProperty.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "pathe";
+import { join, relative } from "pathe";
 import type { PackageJson } from "type-fest";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { PackageJsonRepoDirectoryProperty } from "../../src/policies/PackageJsonRepoDirectoryProperty.js";
@@ -9,6 +9,13 @@ import { runHandler } from "../test-helpers.js";
 
 describe("PackageJsonRepoDirectoryProperty Policy", () => {
 	let testDir: string;
+
+	const createArgs = (file: string, resolve = false) => ({
+		file: relative(testDir, file),
+		root: testDir,
+		resolve,
+		config: undefined,
+	});
 
 	beforeEach(async () => {
 		testDir = await mkdtemp(join(tmpdir(), "repopo-repo-dir-test-"));
@@ -49,15 +56,9 @@ describe("PackageJsonRepoDirectoryProperty Policy", () => {
 
 			await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
-			// Note: file is passed as absolute path to the handler
 			const result = await runHandler(
 				PackageJsonRepoDirectoryProperty.handler,
-				{
-					file: packageJsonPath,
-					root: testDir,
-					resolve: false,
-					config: undefined,
-				},
+				createArgs(packageJsonPath),
 			);
 
 			expect(result).toBe(true);
@@ -76,12 +77,7 @@ describe("PackageJsonRepoDirectoryProperty Policy", () => {
 
 			const result = await runHandler(
 				PackageJsonRepoDirectoryProperty.handler,
-				{
-					file: packageJsonPath,
-					root: testDir,
-					resolve: false,
-					config: undefined,
-				},
+				createArgs(packageJsonPath),
 			);
 
 			expect(result).toBe(true);
@@ -103,12 +99,7 @@ describe("PackageJsonRepoDirectoryProperty Policy", () => {
 
 			const result = await runHandler(
 				PackageJsonRepoDirectoryProperty.handler,
-				{
-					file: packageJsonPath,
-					root: testDir,
-					resolve: false,
-					config: undefined,
-				},
+				createArgs(packageJsonPath),
 			);
 
 			expect(result).toBe(true);
@@ -133,12 +124,7 @@ describe("PackageJsonRepoDirectoryProperty Policy", () => {
 
 			const result = (await runHandler(
 				PackageJsonRepoDirectoryProperty.handler,
-				{
-					file: packageJsonPath,
-					root: testDir,
-					resolve: false,
-					config: undefined,
-				},
+				createArgs(packageJsonPath),
 			)) as PolicyFailure;
 
 			expect(result).not.toBe(true);
@@ -167,12 +153,7 @@ describe("PackageJsonRepoDirectoryProperty Policy", () => {
 
 			const result = (await runHandler(
 				PackageJsonRepoDirectoryProperty.handler,
-				{
-					file: packageJsonPath,
-					root: testDir,
-					resolve: false,
-					config: undefined,
-				},
+				createArgs(packageJsonPath),
 			)) as PolicyFailure;
 
 			expect(result).not.toBe(true);
@@ -200,12 +181,7 @@ describe("PackageJsonRepoDirectoryProperty Policy", () => {
 
 			const result = (await runHandler(
 				PackageJsonRepoDirectoryProperty.handler,
-				{
-					file: packageJsonPath,
-					root: testDir,
-					resolve: true,
-					config: undefined,
-				},
+				createArgs(packageJsonPath, true),
 			)) as PolicyFixResult;
 
 			expect(result.resolved).toBe(true);
@@ -232,12 +208,7 @@ describe("PackageJsonRepoDirectoryProperty Policy", () => {
 
 			const result = (await runHandler(
 				PackageJsonRepoDirectoryProperty.handler,
-				{
-					file: packageJsonPath,
-					root: testDir,
-					resolve: true,
-					config: undefined,
-				},
+				createArgs(packageJsonPath, true),
 			)) as PolicyFixResult;
 
 			expect(result.resolved).toBe(true);
@@ -265,12 +236,10 @@ describe("PackageJsonRepoDirectoryProperty Policy", () => {
 			const originalContent = JSON.stringify(packageJson, null, 2);
 			await writeFile(packageJsonPath, originalContent);
 
-			await runHandler(PackageJsonRepoDirectoryProperty.handler, {
-				file: packageJsonPath,
-				root: testDir,
-				resolve: false,
-				config: undefined,
-			});
+			await runHandler(
+				PackageJsonRepoDirectoryProperty.handler,
+				createArgs(packageJsonPath),
+			);
 
 			const content = await readFile(packageJsonPath, "utf-8");
 			expect(content).toBe(originalContent);
@@ -303,12 +272,7 @@ describe("PackageJsonRepoDirectoryProperty Policy", () => {
 			try {
 				const result = (await runHandler(
 					PackageJsonRepoDirectoryProperty.handler,
-					{
-						file: packageJsonPath,
-						root: testDir,
-						resolve: true,
-						config: undefined,
-					},
+					createArgs(packageJsonPath, true),
 				)) as PolicyFixResult;
 
 				// Policy should return a failure with resolved=false and error messages
@@ -341,12 +305,7 @@ describe("PackageJsonRepoDirectoryProperty Policy", () => {
 
 			const result = await runHandler(
 				PackageJsonRepoDirectoryProperty.handler,
-				{
-					file: packageJsonPath,
-					root: testDir,
-					resolve: false,
-					config: undefined,
-				},
+				createArgs(packageJsonPath),
 			);
 
 			expect(result).toBe(true);
@@ -369,12 +328,10 @@ describe("PackageJsonRepoDirectoryProperty Policy", () => {
 
 			await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 
-			await runHandler(PackageJsonRepoDirectoryProperty.handler, {
-				file: packageJsonPath,
-				root: testDir,
-				resolve: true,
-				config: undefined,
-			});
+			await runHandler(
+				PackageJsonRepoDirectoryProperty.handler,
+				createArgs(packageJsonPath, true),
+			);
 
 			const content = JSON.parse(await readFile(packageJsonPath, "utf-8"));
 			expect(content.repository.type).toBe("git");

--- a/packages/repopo/test/policies/PackageLicense.test.ts
+++ b/packages/repopo/test/policies/PackageLicense.test.ts
@@ -47,14 +47,14 @@ describe("PackageLicense policy", () => {
 		config?: PackageLicenseSettings,
 		resolve = false,
 	): PolicyFunctionArguments<typeof config> => ({
-		file: join(tempDir, file), // Full path for handler to read JSON
+		file,
 		root: tempDir,
 		resolve,
 		config,
 	});
 
 	describe("when package has matching LICENSE", () => {
-		it("should pass validation", async () => {
+		it("should resolve the package path from root when cwd is outside the repository", async () => {
 			const json: PackageJson = {
 				name: "@myorg/test-package",
 				version: "1.0.0",

--- a/packages/repopo/test/policies/PackagePrivateField.test.ts
+++ b/packages/repopo/test/policies/PackagePrivateField.test.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "pathe";
+import { join, relative } from "pathe";
 import type { PackageJson } from "type-fest";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -31,7 +31,7 @@ describe("PackagePrivateField policy", () => {
 		filePath: string,
 		config?: PackagePrivateFieldConfig,
 	): PolicyFunctionArguments<typeof config> => ({
-		file: filePath,
+		file: relative(tempDir, filePath),
 		root: tempDir,
 		resolve: false,
 		config,

--- a/packages/repopo/test/policies/PackageReadme.test.ts
+++ b/packages/repopo/test/policies/PackageReadme.test.ts
@@ -18,12 +18,14 @@ import { runHandler } from "../test-helpers.js";
 
 describe("PackageReadme policy", () => {
 	let tempDir: string;
+	const originalCwd = process.cwd();
 
 	beforeEach(() => {
 		tempDir = mkdtempSync(join(tmpdir(), "repopo-readme-test-"));
 	});
 
 	afterEach(() => {
+		process.chdir(originalCwd);
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
@@ -43,19 +45,20 @@ describe("PackageReadme policy", () => {
 		config?: PackageReadmeSettings,
 		resolve = false,
 	): PolicyFunctionArguments<typeof config> => ({
-		file: join(tempDir, file),
+		file,
 		root: tempDir,
 		resolve,
 		config,
 	});
 
 	describe("when README exists with matching title", () => {
-		it("should pass validation", async () => {
+		it("should resolve the package path from root when run from a repository subdirectory", async () => {
 			const json: PackageJson = {
 				name: "@myorg/test-package",
 				version: "1.0.0",
 			};
 			const file = createPackageJson(json);
+			process.chdir(join(tempDir, "packages"));
 			writeFileSync(
 				join(tempDir, "packages/my-pkg/README.md"),
 				"# @myorg/test-package\n\nSome content.",

--- a/packages/repopo/test/policies/PackageScripts.test.ts
+++ b/packages/repopo/test/policies/PackageScripts.test.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "pathe";
+import { join, relative } from "pathe";
 import type { PackageJson } from "type-fest";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -32,7 +32,7 @@ describe("PackageScripts policy", () => {
 		config?: PackageScriptsSettings,
 		resolve = false,
 	): PolicyFunctionArguments<typeof config> => ({
-		file: filePath,
+		file: relative(tempDir, filePath),
 		root: tempDir,
 		resolve,
 		config,

--- a/packages/repopo/test/policies/PackageTestScripts.test.ts
+++ b/packages/repopo/test/policies/PackageTestScripts.test.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "pathe";
+import { join, relative } from "pathe";
 import type { PackageJson } from "type-fest";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -38,7 +38,7 @@ describe("PackageTestScripts policy", () => {
 		filePath: string,
 		config?: PackageTestScriptsConfig,
 	): PolicyFunctionArguments<typeof config> => ({
-		file: filePath,
+		file: relative(tempDir, filePath),
 		root: tempDir,
 		resolve: false,
 		config,

--- a/packages/repopo/test/policies/RequiredScripts.test.ts
+++ b/packages/repopo/test/policies/RequiredScripts.test.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "pathe";
+import { join, relative } from "pathe";
 import type { PackageJson } from "type-fest";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -32,7 +32,7 @@ describe("RequiredScripts policy", () => {
 		config?: RequiredScriptsConfig,
 		resolve = false,
 	): PolicyArgs<typeof config> => ({
-		file: filePath,
+		file: relative(tempDir, filePath),
 		root: tempDir,
 		resolve,
 		config,


### PR DESCRIPTION
## Summary

- resolve built-in policy filesystem paths from `PolicyArgs.root` and repository-relative `PolicyArgs.file`
- fix package license, README, repository directory, ESM type, private field, package properties, file-header, test-script detection, and script-policy fix paths
- update policy tests to consistently use repository-relative paths, including execution outside the repository root and from a repository subdirectory
- add a patch changeset for `repopo`

Closes #770.
